### PR TITLE
FAC-132 support snappy tmp volume/volumeMount

### DIFF
--- a/charts/kpow-ce/templates/deployment.yaml
+++ b/charts/kpow-ce/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: http
               containerPort: 3000
               protocol: TCP
-          {{- if or .Values.volumeMounts (and .Values.snappyTmp .Values.snappyTmp.enabled) }}
+          {{- if or .Values.volumeMounts .Values.snappyTmp.enabled }}
           volumeMounts:
             {{- if .Values.volumeMounts }}
               {{- toYaml .Values.volumeMounts | nindent 12 }}
@@ -92,7 +92,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or .Values.volumes (and .Values.snappyTmp .Values.snappyTmp.enabled) }}
+      {{- if or .Values.volumes .Values.snappyTmp.enabled }}
       volumes:
         {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 8 }}

--- a/charts/kpow-ce/templates/deployment.yaml
+++ b/charts/kpow-ce/templates/deployment.yaml
@@ -56,14 +56,14 @@ spec:
             - name: http
               containerPort: 3000
               protocol: TCP
-          {{- if or .Values.volumeMounts .Values.snappyTmp.enabled }}
+          {{- if or .Values.volumeMounts .Values.ephemeralTmp.enabled }}
           volumeMounts:
             {{- if .Values.volumeMounts }}
               {{- toYaml .Values.volumeMounts | nindent 12 }}
             {{- end }}
-            {{- if .Values.snappyTmp.enabled }}
-            - name: {{ .Values.snappyTmp.volumeMount.name | quote }}
-              mountPath: {{ .Values.snappyTmp.volumeMount.mountPath | quote }}
+            {{- if .Values.ephemeralTmp.enabled }}
+            - name: {{ .Values.ephemeralTmp.volumeMount.name | quote }}
+              mountPath: {{ .Values.ephemeralTmp.volumeMount.mountPath | quote }}
             {{- end }}
           {{- end }}
           readinessProbe:
@@ -92,17 +92,17 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or .Values.volumes .Values.snappyTmp.enabled }}
+      {{- if or .Values.volumes .Values.ephemeralTmp.enabled }}
       volumes:
         {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 8 }}
         {{- end }}
-        {{- if .Values.snappyTmp.enabled }}
-        - name: {{ .Values.snappyTmp.volumeMount.name | quote }}
+        {{- if .Values.ephemeralTmp.enabled }}
+        - name: {{ .Values.ephemeralTmp.volumeMount.name | quote }}
           {{- /* Check if emptyDir config exists, otherwise provide a default empty one */}}
-          {{- if .Values.snappyTmp.volume.emptyDir }}
+          {{- if .Values.ephemeralTmp.volume.emptyDir }}
           emptyDir:
-            {{- toYaml .Values.snappyTmp.volume.emptyDir | nindent 12 }}
+            {{- toYaml .Values.ephemeralTmp.volume.emptyDir | nindent 12 }}
           {{- else }}
           emptyDir: {} # Default emptyDir if no specific config
           {{- end }}

--- a/charts/kpow-ce/templates/deployment.yaml
+++ b/charts/kpow-ce/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.volumes }}
+      {{- if or .Values.volumes (and .Values.snappyTmp .Values.snappyTmp.enabled) }}
       volumes:
         {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 8 }}

--- a/charts/kpow-ce/templates/deployment.yaml
+++ b/charts/kpow-ce/templates/deployment.yaml
@@ -56,9 +56,15 @@ spec:
             - name: http
               containerPort: 3000
               protocol: TCP
-          {{- with .Values.volumeMounts }}
+          {{- if or .Values.volumeMounts (and .Values.snappyTmp .Values.snappyTmp.enabled) }}
           volumeMounts:
-            {{- toYaml . | nindent 12 }}
+            {{- if .Values.volumeMounts }}
+              {{- toYaml .Values.volumeMounts | nindent 12 }}
+            {{- end }}
+            {{- if .Values.snappyTmp.enabled }}
+            - name: {{ .Values.snappyTmp.volumeMount.name | quote }}
+              mountPath: {{ .Values.snappyTmp.volumeMount.mountPath | quote }}
+            {{- end }}
           {{- end }}
           readinessProbe:
             httpGet:
@@ -88,5 +94,17 @@ spec:
       {{- end }}
       {{- with .Values.volumes }}
       volumes:
-        {{- toYaml . | nindent 8 }}
+        {{- if .Values.volumes }}
+          {{- toYaml .Values.volumes | nindent 8 }}
+        {{- end }}
+        {{- if .Values.snappyTmp.enabled }}
+        - name: {{ .Values.snappyTmp.volumeMount.name | quote }}
+          {{- /* Check if emptyDir config exists, otherwise provide a default empty one */}}
+          {{- if .Values.snappyTmp.volume.emptyDir }}
+          emptyDir:
+            {{- toYaml .Values.snappyTmp.volume.emptyDir | nindent 12 }}
+          {{- else }}
+          emptyDir: {} # Default emptyDir if no specific config
+          {{- end }}
+        {{- end }}
       {{- end }}

--- a/charts/kpow-ce/values.yaml
+++ b/charts/kpow-ce/values.yaml
@@ -20,6 +20,16 @@ volumes: []
 #   configMap:
 #     name: "my-kpow-ce-config"
 
+snappyTmp:
+  enabled: false # Sets up an emptyDir volume mount for Snappy compression. Enable this if you use Snappy compression and you have readOnly filesystem Pod policies.
+  volumeMount:
+    name: "snappy-tmp"
+    mountPath: "/opt/snappy-tmp"
+  volume:
+    emptyDir:
+      medium: Memory # Optional: for better performance
+      sizeLimit: "100Mi" # Configurable size
+
 serviceAccount:
   create: true
   annotations: {}

--- a/charts/kpow-ce/values.yaml
+++ b/charts/kpow-ce/values.yaml
@@ -4,27 +4,29 @@ image:
   repository: factorhouse/kpow-ce
   pullPolicy: IfNotPresent
 
-imagePullSecrets: []
+imagePullSecrets: [ ]
 nameOverride: ""
 fullnameOverride: ""
 
-env: {}
+env: { }
 envFromConfigMap: null
 envFromSecret: null
-volumeMounts: []
+volumeMounts: [ ]
 # - name: rbac-config
 #   mountPath: /path/to/rbac-config.yaml
 #   subPath: rbac-config.yaml
-volumes: []
+volumes: [ ]
 # - name: rbac-config
 #   configMap:
 #     name: "my-kpow-ce-config"
 
-snappyTmp:
-  enabled: false # Sets up an emptyDir volume mount for Snappy compression. Enable this if you use Snappy compression and you have readOnly filesystem Pod policies.
+ephemeralTmp:
+  # Sets up an emptyDir volume mount for Snappy compression and other features requiring /tmp access.
+  # Enable this if you use Snappy compression and you have readOnly filesystem Pod policies.
+  enabled: false
   volumeMount:
-    name: "snappy-tmp"
-    mountPath: "/opt/snappy-tmp"
+    name: "fh-tmp"
+    mountPath: "/opt/factorhouse/tmp"
   volume:
     emptyDir:
       medium: Memory # Optional: for better performance
@@ -32,26 +34,26 @@ snappyTmp:
 
 serviceAccount:
   create: true
-  annotations: {}
+  annotations: { }
   name: kpow-ce
 
-podAnnotations: {}
+podAnnotations: { }
 
-podSecurityContext: {}
+podSecurityContext: { }
 
-securityContext: {}
+securityContext: { }
 
 service:
   enabled: true
-  annotations: {}
+  annotations: { }
   type: ClusterIP
   port: 3000
 
 ingress:
   enabled: false
-  annotations: {}
-  hosts: []
-  tls: []
+  annotations: { }
+  hosts: [ ]
+  tls: [ ]
   ingressClassName: ""
 
 # We recommend running Kpow Community w/ Guaranteed QOS
@@ -71,10 +73,10 @@ autoscaling:
   targetCPUUtilizationPercentage: 85
   targetMemoryUtilizationPercentage: 85
 
-nodeSelector: {}
+nodeSelector: { }
 
-tolerations: []
+tolerations: [ ]
 
-affinity: {}
+affinity: { }
 
-labels: {}
+labels: { }

--- a/charts/kpow/README.md
+++ b/charts/kpow/README.md
@@ -19,6 +19,7 @@ container on Dockerhub.
     * [Manage Sensitive Environment Variables](#manage-sensitive-environment-variables)
     * [Provide Files to the Kpow Pod](#provide-files-to-the-kpow-pod)
     * [Kpow Memory and CPU Requirements](#kpow-memory-and-cpu-requirements)
+    * [Snappy compression in read-only filesystem](#snappy-compression-in-read-only-filesystem)
 
 ## Prerequisites
 
@@ -305,6 +306,19 @@ helm install --namespace factorhouse --create-namespace kpow factorhouse/kpow \
 
 We recommend always having limits and requests set to the same value, as this set Kpow in Guaranteed QoS and provides a
 much more reliable operation.
+
+#### Snappy compression in read-only filesystem
+
+We preset an attribute for Snappy compression in read-only filesystems. It is disabled by default and can be enabled - modify the volume configuration if necessary.
+
+```yaml
+snappyTmp:
+  enabled: false # Set to true
+  volume:
+    emptyDir:
+      medium: Memory # Optional: for better performance
+      sizeLimit: "100Mi" # Configurable size
+```
 
 ### Get Help!
 

--- a/charts/kpow/README.md
+++ b/charts/kpow/README.md
@@ -309,11 +309,12 @@ much more reliable operation.
 
 #### Snappy compression in read-only filesystem
 
-We preset an attribute for Snappy compression in read-only filesystems. It is disabled by default and can be enabled - modify the volume configuration if necessary.
+We preset an attribute for Snappy compression in read-only filesystems. It is disabled by default and can be enabled -
+modify the volume configuration if necessary.
 
 ```yaml
-snappyTmp:
-  enabled: false # Set to true
+ephemeralTmp:
+  enabled: true
   volume:
     emptyDir:
       medium: Memory # Optional: for better performance

--- a/charts/kpow/templates/deployment.yaml
+++ b/charts/kpow/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: http
               containerPort: 3000
               protocol: TCP
-          {{- if or .Values.volumeMounts (and .Values.snappyTmp .Values.snappyTmp.enabled) }}
+          {{- if or .Values.volumeMounts .Values.snappyTmp.enabled }}
           volumeMounts:
             {{- if .Values.volumeMounts }}
               {{- toYaml .Values.volumeMounts | nindent 12 }}
@@ -92,7 +92,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or .Values.volumes (and .Values.snappyTmp .Values.snappyTmp.enabled) }}
+      {{- if or .Values.volumes .Values.snappyTmp.enabled }}
       volumes:
         {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 8 }}

--- a/charts/kpow/templates/deployment.yaml
+++ b/charts/kpow/templates/deployment.yaml
@@ -56,14 +56,14 @@ spec:
             - name: http
               containerPort: 3000
               protocol: TCP
-          {{- if or .Values.volumeMounts .Values.snappyTmp.enabled }}
+          {{- if or .Values.volumeMounts .Values.ephemeralTmp.enabled }}
           volumeMounts:
             {{- if .Values.volumeMounts }}
               {{- toYaml .Values.volumeMounts | nindent 12 }}
             {{- end }}
-            {{- if .Values.snappyTmp.enabled }}
-            - name: {{ .Values.snappyTmp.volumeMount.name | quote }}
-              mountPath: {{ .Values.snappyTmp.volumeMount.mountPath | quote }}
+            {{- if .Values.ephemeralTmp.enabled }}
+            - name: {{ .Values.ephemeralTmp.volumeMount.name | quote }}
+              mountPath: {{ .Values.ephemeralTmp.volumeMount.mountPath | quote }}
             {{- end }}
           {{- end }}
           readinessProbe:
@@ -92,17 +92,17 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or .Values.volumes .Values.snappyTmp.enabled }}
+      {{- if or .Values.volumes .Values.ephemeralTmp.enabled }}
       volumes:
         {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 8 }}
         {{- end }}
-        {{- if .Values.snappyTmp.enabled }}
-        - name: {{ .Values.snappyTmp.volumeMount.name | quote }}
+        {{- if .Values.ephemeralTmp.enabled }}
+        - name: {{ .Values.ephemeralTmp.volumeMount.name | quote }}
           {{- /* Check if emptyDir config exists, otherwise provide a default empty one */}}
-          {{- if .Values.snappyTmp.volume.emptyDir }}
+          {{- if .Values.ephemeralTmp.volume.emptyDir }}
           emptyDir:
-            {{- toYaml .Values.snappyTmp.volume.emptyDir | nindent 12 }}
+            {{- toYaml .Values.ephemeralTmp.volume.emptyDir | nindent 12 }}
           {{- else }}
           emptyDir: {} # Default emptyDir if no specific config
           {{- end }}

--- a/charts/kpow/templates/deployment.yaml
+++ b/charts/kpow/templates/deployment.yaml
@@ -58,7 +58,13 @@ spec:
               protocol: TCP
           {{- with .Values.volumeMounts }}
           volumeMounts:
-            {{- toYaml . | nindent 12 }}
+            {{- if .Values.volumeMounts }}
+              {{- toYaml .Values.volumeMounts | nindent 12 }}
+            {{- end }}
+            {{- if .Values.snappyTmp.enabled }}
+            - name: {{ .Values.snappyTmp.volumeMount.name | quote }}
+              mountPath: {{ .Values.snappyTmp.volumeMount.mountPath | quote }}
+            {{- end }}
           {{- end }}
           readinessProbe:
             httpGet:
@@ -88,5 +94,17 @@ spec:
       {{- end }}
       {{- with .Values.volumes }}
       volumes:
-        {{- toYaml . | nindent 8 }}
+        {{- if .Values.volumes }}
+          {{- toYaml .Values.volumes | nindent 8 }}
+        {{- end }}
+        {{- if .Values.snappyTmp.enabled }}
+        - name: {{ .Values.snappyTmp.volumeMount.name | quote }}
+          {{- /* Check if emptyDir config exists, otherwise provide a default empty one */}}
+          {{- if .Values.snappyTmp.volume.emptyDir }}
+          emptyDir:
+            {{- toYaml .Values.snappyTmp.volume.emptyDir | nindent 12 }}
+          {{- else }}
+          emptyDir: {} # Default emptyDir if no specific config
+          {{- end }}
+        {{- end }}
       {{- end }}

--- a/charts/kpow/templates/deployment.yaml
+++ b/charts/kpow/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: http
               containerPort: 3000
               protocol: TCP
-          {{- with .Values.volumeMounts }}
+          {{- if or .Values.volumeMounts (and .Values.snappyTmp .Values.snappyTmp.enabled) }}
           volumeMounts:
             {{- if .Values.volumeMounts }}
               {{- toYaml .Values.volumeMounts | nindent 12 }}
@@ -92,7 +92,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.volumes }}
+      {{- if or .Values.volumes (and .Values.snappyTmp .Values.snappyTmp.enabled) }}
       volumes:
         {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 8 }}

--- a/charts/kpow/values.yaml
+++ b/charts/kpow/values.yaml
@@ -20,6 +20,16 @@ volumes: []
 #   configMap:
 #     name: "my-kpow-config"
 
+snappyTmp:
+  enabled: false # Sets up an emptyDir volume mount for Snappy compression. Enable this if you use Snappy compression and you have readOnly filesystem Pod policies.
+  volumeMount:
+    name: "snappy-tmp"
+    mountPath: "/opt/snappy-tmp"
+  volume:
+    emptyDir:
+      medium: Memory # Optional: for better performance
+      sizeLimit: "100Mi" # Configurable size
+
 serviceAccount:
   create: true
   annotations: {}

--- a/charts/kpow/values.yaml
+++ b/charts/kpow/values.yaml
@@ -4,27 +4,29 @@ image:
   repository: factorhouse/kpow
   pullPolicy: IfNotPresent
 
-imagePullSecrets: []
+imagePullSecrets: [ ]
 nameOverride: ""
 fullnameOverride: ""
 
-env: {}
+env: { }
 envFromConfigMap: null
 envFromSecret: null
-volumeMounts: []
+volumeMounts: [ ]
 # - name: rbac-config
 #   mountPath: /path/to/rbac-config.yaml
 #   subPath: rbac-config.yaml
-volumes: []
+volumes: [ ]
 # - name: rbac-config
 #   configMap:
 #     name: "my-kpow-config"
 
-snappyTmp:
-  enabled: false # Sets up an emptyDir volume mount for Snappy compression. Enable this if you use Snappy compression and you have readOnly filesystem Pod policies.
+ephemeralTmp:
+  # Sets up an emptyDir volume mount for Snappy compression and other features requiring /tmp access.
+  # Enable this if you use Snappy compression and you have readOnly filesystem Pod policies.
+  enabled: false
   volumeMount:
-    name: "snappy-tmp"
-    mountPath: "/opt/snappy-tmp"
+    name: "fh-tmp"
+    mountPath: "/opt/factorhouse/tmp"
   volume:
     emptyDir:
       medium: Memory # Optional: for better performance
@@ -32,26 +34,26 @@ snappyTmp:
 
 serviceAccount:
   create: true
-  annotations: {}
+  annotations: { }
   name: kpow
 
-podAnnotations: {}
+podAnnotations: { }
 
-podSecurityContext: {}
+podSecurityContext: { }
 
-securityContext: {}
+securityContext: { }
 
 service:
   enabled: true
-  annotations: {}
+  annotations: { }
   type: ClusterIP
   port: 3000
 
 ingress:
   enabled: false
-  annotations: {}
-  hosts: []
-  tls: []
+  annotations: { }
+  hosts: [ ]
+  tls: [ ]
   ingressClassName: ""
 
 # We recommend running Kpow w/ Guaranteed QOS
@@ -75,10 +77,10 @@ autoscaling:
   targetCPUUtilizationPercentage: 85
   targetMemoryUtilizationPercentage: 85
 
-nodeSelector: {}
+nodeSelector: { }
 
-tolerations: []
+tolerations: [ ]
 
-affinity: {}
+affinity: { }
 
-labels: {}
+labels: { }


### PR DESCRIPTION
FAC-132
- https://linear.app/factor-house/issue/FAC-132/add-snappy-tmp-volumevolumemount-to-helm

values.yml

```
snappyTmp:
  enabled: true # Allow customers to toggle this feature
  volumeMount:
    name: "snappy-tmp"
    mountPath: "/opt/snappy-tmp"
  volume:
    emptyDir:
      medium: Memory # Optional: for better performance
      sizeLimit: "100Mi" # Configurable size
```

![image](https://github.com/user-attachments/assets/dd0f0f06-0c34-4b33-afdf-942d1082058a)

