### PR TITLE
Consolidate the Helm chart for Kpow Annual

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,11 @@
 name: Release Charts
 
-on:
-  push:
-    branches:
-      - main
+on: [push]
+
+# on:
+#   push:
+#     branches:
+#       - main
 
 jobs:
   release:
@@ -57,6 +59,8 @@ jobs:
 
       - name: Run chart-releaser #this is used to generate new version of helm chart along with some file with extension .prov
         uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 #v1.6.0
+        with:
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_KEY: "${{ secrets.CR_KEY }}" # Key name used while creating key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,9 @@
 name: Release Charts
 
-on: [push]
-
-# on:
-#   push:
-#     branches:
-#       - main
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Official Helm Charts for Factor House products. Currently supported:
 
 * [Kpow](charts/kpow/README.md) (`factorhouse/kpow`)
 * [Kpow Community Edition](charts/kpow-ce/README.md) (`factorhouse/kpow-ce`)
+* [Kpow AWS Marketplace (Kpow Annual)](charts/kpow-annual/README.md)(`factorhouse/kpow-annual-chart`)
 * [Flex](charts/flex/README.md) (`factorhouse/flex`)
 * [Flex Community Edition](charts/flex-ce/README.md) (`factorhouse/flex-ce`)
 

--- a/charts/flex-ce/values.schema.json
+++ b/charts/flex-ce/values.schema.json
@@ -114,6 +114,17 @@
                 "allowPrivilegeEscalation": {
                     "type": "boolean"
                 },
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
                 "privileged": {
                     "type": "boolean"
                 },

--- a/charts/flex/values.schema.json
+++ b/charts/flex/values.schema.json
@@ -114,6 +114,17 @@
                 "allowPrivilegeEscalation": {
                     "type": "boolean"
                 },
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
                 "privileged": {
                     "type": "boolean"
                 },

--- a/charts/kpow-annual/.helmignore
+++ b/charts/kpow-annual/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kpow-annual/Chart.yaml
+++ b/charts/kpow-annual/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kpow-annual-chart
 description: Run Kpow Annual from the AWS Marketplace in Kubernetes
 type: application
-version: 0.1.0
+version: 1.0.59
 appVersion: "94.5"
 keywords:
   - kafka

--- a/charts/kpow-annual/Chart.yaml
+++ b/charts/kpow-annual/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kpow-annual-chart
 description: Run Kpow Annual from the AWS Marketplace in Kubernetes
 type: application
-version: 1.0.59
+version: 0.1.0
 appVersion: "94.5"
 keywords:
   - kafka

--- a/charts/kpow-annual/Chart.yaml
+++ b/charts/kpow-annual/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: kpow-annual-chart
+description: Run Kpow Annual from the AWS Marketplace in Kubernetes
+type: application
+version: 1.0.59
+appVersion: "94.5"
+keywords:
+  - kafka
+  - kafka-ui
+  - kafka-connect
+  - schema-registry
+  - monitoring
+home: "https://factorhouse.io/kpow"
+sources:
+  - "https://github.com/factorhouse/kpow"
+  - "https://github.com/factorhouse/kpow-helm-charts-lm/"
+maintainers:
+  - name: "Factor House Support"
+    email: "support@factorhouse.io"

--- a/charts/kpow-annual/Chart.yaml
+++ b/charts/kpow-annual/Chart.yaml
@@ -13,7 +13,11 @@ keywords:
 home: "https://factorhouse.io/kpow"
 sources:
   - "https://github.com/factorhouse/kpow"
-  - "https://github.com/factorhouse/kpow-helm-charts-lm/"
+  - "https://github.com/factorhouse/helm-charts/"
 maintainers:
   - name: "Factor House Support"
     email: "support@factorhouse.io"
+annotations:
+  artifacthub.io/signKey: |
+      fingerprint: 9686853629F9810E63A72373BA3D0FAE1A26981F
+      url: https://keybase.io/factorhouse/pgp_keys.asc

--- a/charts/kpow-annual/README.md
+++ b/charts/kpow-annual/README.md
@@ -1,0 +1,29 @@
+## Run Kpow for Apache Kafka in Kubernetes with AWS License Manager
+
+[Helm](https://helm.sh) is the package manager for Kubernetes.
+
+[Kpow](https://kpow.io) is the all-in-one toolkit to manage, monitor, and learn about your Kafka resources.
+
+This Helm chart is applicable to the **AWS License Manager** version of Kpow [sold on the AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-vgghgqdsplhvc).
+
+Find our general-purpose Helm charts for regular Kubernetes deploys [right here](https://github.com/factorhouse/kpow-helm-charts).
+
+## Helm Charts
+
+This repository contains a single Helm chart that uses the Kpow AWS Marketplace LM Docker container provided to you when you subscribe to the Kpow AWS Marketplace LM product on the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-vgghgqdsplhvc).
+
+### Installation
+
+Follow the instructions provided to you via your AWS Marketplace subscription.
+
+For more information on configuring IAM Roles for Service Accounts see our [Kpow AWS-LM Documentation](https://docs.kpow.io/installation/aws-marketplace-lm/).
+
+For general purpose configuration instructions see our [general-purpose Helm charts](https://github.com/factorhouse/kpow-helm-charts).
+
+### Get Help!
+
+If you have any issues or errors, please contact support@factorhouse.io.
+
+### Licensing and Modifications
+
+This repository is Apache 2.0 licensed, you are welcome to clone and modify as required.

--- a/charts/kpow-annual/kpow-config.yaml.example
+++ b/charts/kpow-annual/kpow-config.yaml.example
@@ -1,0 +1,167 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kpow-config
+data:
+
+  ### See https://docs.kpow.io for full configuration and installation guides
+
+  ### Note: The simplest Kpow configuration requires only LICENSE_* and BOOTSTRAP.
+
+  ### License Configuration (https://kpow.io/try <- 30 day trial licenses available)
+  ### Note: If using the AWS Marketplace Kpow Container you do not need to supply LICENSE* parameters
+  ###       (https://aws.amazon.com/marketplace/seller-profile?id=ab356f1d-3394-4523-b5d4-b339e3cca9e0)
+
+  LICENSE_ID: "replace-me"
+  LICENSE_CODE: "replace-me"
+  LICENSEE: "replace-me"
+  LICENSE_EXPIRY: "replace-me"
+  LICENSE_SIGNATURE: "replace-me"
+
+  ### Resource Set Configuration
+
+  ### Kpow manages sets of Kafka resources. Clusters, Schema Registries and Kafka Connect Installations.
+  ### To configure multiple kafka resources prepend environment variables with _2, _3, etc.
+  ### Resources with the same set-id are considered related.
+  ###   E.g. cluster with BOOTSTRAP_2 can decode messages from with registry SCHEMA_REGISTRY_URL_2.
+
+  ## Optional Resource Set Name (this is displayed in the Kpow UI for each set of resources)
+
+  ENVIRONMENT_NAME: "Change Me"
+
+  ## Kafka Cluster Configuration
+  ## Required parameters for configuring a Kafka Cluster
+  ## You must configure at least one Kafka Booktstrap to use Kpow.
+
+  BOOTSTRAP: "replace-with-your-bootstrap-url"
+
+  ## Optional Kafka Cluster Configuration
+
+  # SECURITY_PROTOCOL: SASL_SSL
+  # SASL_MECHANISM: PLAIN
+  # SASL_JAAS_CONFIG: "org.apache.kafka.common.security.plain.Plain.."
+  # SASL_LOGIN_CALLBACK_HANDLER_CLASS: "com.corp.kafka.security.sasl.oauth.KafkaBrokerTokenCreator"
+  # SSL_KEYSTORE_LOCATION: "/ssl/kafka.keystore.jks"
+  # SSL_KEYSTORE_PASSWORD: "keystore-pass-123"
+  # SSL_KEY_PASSWORD: "key-pass-123"
+  # SSL_KEYSTORE_TYPE: JKS
+  # SSL_KEYMANAGER_ALGORITHM: SunX509
+  # SSL_TRUSTSTORE_LOCATION: "/ssl/kafka.truststore.jks"
+  # SSL_TRUSTSTORE_PASSWORD: "trust-pass-123"
+  # SSL_TRUSTSTORE_TYPE: JKS
+  # SSL_TRUSTMANAGER_ALGORITHM: PKIX
+  # SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: https
+  # SSL_PROVIDER: default
+  # SSL_CIPHER_SUITES: default
+  # SSL_PROTOCOL: TLS
+  # SSL_ENABLED_PROTOCOLS: "TLSv.12,TLSv1.1,TLSv1"
+  # SSL_SECURE_RANDOM_IMPLEMENTATION: SHA1PRNG
+
+  ## Schema Registry Configuration
+
+  # SCHEMA_REGISTRY_URL: https://registry-host
+  # SCHEMA_REGISTRY_AUTH: USER_INFO
+  # SCHEMA_REGISTRY_USER: registry-user
+  # SCHEMA_REGISTRY_PASSWORD: registry-pass
+  # SCHEMA_REGISTRY_NAME: registry-label (optional)
+
+  ## Kafka Connect Configuration
+
+  # CONNECT_REST_URL: http://localhost:8083
+  # CONNECT_AUTH: BASIC (optional)
+  # CONNECT_BASIC_AUTH_USER: connect-user (optional)
+  # CONNECT_BASIC_AUTH_PASS: connect-pass (optional)
+  # CONNECT_GROUP_ID: connect-group-id (optional)
+  # CONNECT_OFFSET_STORAGE_TOPIC: connect-topic (optional)
+
+  ### System Configuration
+
+  # PORT: 3000 - the port to serve content
+  # REPLICATION_FACTOR: 3 - the replication factor of internal kpow topics (reduce if you have fewer than 3 brokers)
+  # SNAPSHOT_PARALLELISM: 3 - the parallelism of kpow snapshot execution (increase for very big resource-sets)
+  # SHOW_SPLASH: true - turn on/off the initial splash screen for new user sessions
+
+  ### Live Mode Configuration
+
+  # LIVE_MODE_ENABLED=true
+  # LIVE_MODE_PERIOD_MS=60000
+  # LIVE_MODE_INTERVAL_MS=5000
+  # LIVE_MODE_MAX_CONCURRENT_USERS=2
+
+  ## System HTTPS Configuration
+
+  # ENABLE_HTTPS: "true"
+  # HTTPS_KEYSTORE_LOCATION: "/ssl/https.keystore.jks"
+  # HTTPS_KEYSTORE_TYPE: "JKS"
+  # HTTPS_KEYSTORE_PASSWORD: "ssl-key-pass"
+  # HTTPS_TRUSTSTORE_LOCATION: "/ssl/https.truststore.jks"
+  # HTTPS_TRUSTSTORE_TYPE: "JKS"
+  # HTTPS_TRUSTSTORE_PASSWORD: "ssl-trust-pass"
+
+  ## Data Inspect Configuration
+  ## Provide custom serdes, set the default serdes, and restrict serdes available to users.
+
+  # CUSTOM_SERDES: "io.kpow.SerdeOne,io.kpow.SerdeTwo"
+  # DEFAULT_KEY_SERDES: "JSON"
+  # DEFAULT_VALUE_SERDES: "AVRO"
+  # AVAILABLE_KEY_SERDES: "JSON,String,Transit / JSON"
+  # AVAILABLE_VALUE_SERDES: "JSON,String,io.kpow.SerdeOne"
+
+  ## Prometheus Endpoints
+
+  # PROMETHEUS_EGRESS: "true"
+
+  ### User Authentication and Authorization
+
+  ## RBAC Configuration (requires SSO provider configured, e.g. Okta, Github, Azure AD, AWS SSO, SAML, etc.)
+
+  # RBAC_CONFIGURATION_FILE: /opt/kpow/rbac-config.yaml
+
+  ## Global Access Controls Configuration (default to false, apply to all users, overriden if you configure RBAC)
+
+  # ALLOW_TOPIC_CREATE: "true"
+  # ALLOW_TOPIC_DELETE: "true"
+  # ALLOW_TOPIC_INSPECT: "true"
+  # ALLOW_TOPIC_PRODUCE: "true"
+  # ALLOW_TOPIC_EDIT: "true"
+  # ALLOW_BROKER_EDIT: "true"
+  # ALLOW_GROUP_EDIT: "true"
+  # ALLOW_SCHEMA_CREATE: "true"
+  # ALLOW_SCHEMA_EDIT: "true"
+  # ALLOW_CONNECT_CREATE: "true"
+  # ALLOW_CONNECT_EDIT: "true"
+  # ALLOW_ACL_EDIT: "true"
+
+  ## Data Policy (Masking / Redaction) Configuration
+
+  # DATA_POLICY_CONFIGURATION_FILE: /opt/kpow/data-config.yml
+
+  ## Slack Integration (Send Audit Log records to a Slack channel)
+
+  # SLACK_WEBHOOK_URL: https://hooks.slack.com/services/...
+
+  ## Okta SSO (OpenID)
+
+  # AUTH_PROVIDER_TYPE: "okta"
+  # OKTA_ORGANISATION: "your-organisation"
+  # OPENID_CLIENT_ID: "The 'Client ID' found in the "Client Credentials" section of your Okta integration"
+  # OPENID_CLIENT_SECRET: "The 'Client Secret' found in the "Client Credentials" section of your Okta integration"
+  # OPENID_LANDING_URI: "https://staging.kpow.z-corp.com"
+
+  ## Github SSO (OpenID)
+
+  # AUTH_PROVIDER_TYPE: "github"
+  # OPENID_TOKEN_URI: "https://github.com/login/oauth/access_token" or "[GHE Server URL]/login/oauth/access_token"
+  # OPENID_AUTH_URI: "https://github.com/login/oauth/authorize" or "[GHE Server URL]/login/oauth/authorize"
+  # OPENID_API_URI: "https://api.github.com/user" or, "[GHE Server URL]/api/v3/user"
+  # OPENID_CLIENT_ID: "The 'Client ID' found in your configured Github Oath App"
+  # OPENID_CLIENT_SECRET: "The 'Client Secret' found in your configured Github Oath App"
+  # OPENID_LANDING_URI: "https://staging.kpow.z-corp.com/"
+
+  ## SAML SSO
+
+  # AUTH_PROVIDER_TYPE: "saml"
+  # SAML_RELYING_PARTY_IDENTIFIER: "kpow.io"
+  # SAML_ACS_URL: "https://kpow.corp.com/saml"
+  # SAML_METADATA_FILE: "/opt/kpow/aws-metadata.xml"
+  # SAML_CERT: "/var/certs/saml-cert.cer"

--- a/charts/kpow-annual/templates/NOTES.txt
+++ b/charts/kpow-annual/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kpow.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "kpow.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "kpow.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kpow.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:3000 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 3000:3000
+{{- end }}

--- a/charts/kpow-annual/templates/_helpers.tpl
+++ b/charts/kpow-annual/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kpow.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kpow.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kpow.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kpow.labels" -}}
+helm.sh/chart: {{ include "kpow.chart" . }}
+{{ include "kpow.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kpow.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kpow.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kpow.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kpow.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/kpow-annual/templates/_helpers.tpl
+++ b/charts/kpow-annual/templates/_helpers.tpl
@@ -52,6 +52,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Provided labels
+*/}}
+{{- define "kpow.providedLabels" -}}
+{{- if .Values.labels }}
+{{- toYaml .Values.labels }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "kpow.serviceAccountName" -}}

--- a/charts/kpow-annual/templates/deployment.yaml
+++ b/charts/kpow-annual/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "kpow.labels" . | nindent 4 }}
+    {{- include "kpow.providedLabels" . | nindent 4 }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -20,6 +21,7 @@ spec:
     {{- end }}
       labels:
         {{- include "kpow.selectorLabels" . | nindent 8 }}
+        {{- include "kpow.providedLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -50,6 +52,7 @@ spec:
                   name: {{ $.Values.aws.licenseConfigSecretName }}
                   key: iam_role
             {{- end }}
+          {{- if or .Values.envFromConfigMap .Values.envFromSecret }}
           envFrom:
             {{- with .Values.envFromConfigMap }}
             - configMapRef:
@@ -59,13 +62,18 @@ spec:
             - secretRef:
                 name: {{ . }}
             {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 3000
               protocol: TCP
           volumeMounts:
-            {{- with .Values.volumeMounts }}
-            {{- toYaml . | nindent 12 }}
+            {{- if .Values.volumeMounts }}
+              {{- toYaml .Values.volumeMounts | nindent 12 }}
+            {{- end }}
+            {{- if .Values.ephemeralTmp.enabled }}
+            - name: {{ .Values.ephemeralTmp.volumeMount.name | quote }}
+              mountPath: {{ .Values.ephemeralTmp.volumeMount.mountPath | quote }}
             {{- end }}
             {{- if $.Values.aws.licenseConfigSecretName }}
             - name: awsmp-product-license
@@ -85,16 +93,6 @@ spec:
             periodSeconds: 30
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      volumes:
-        {{- with .Values.volumes }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- if $.Values.aws.licenseConfigSecretName }}
-        - name: awsmp-product-license
-          secret:
-            secretName: {{ $.Values.aws.licenseConfigSecretName }}
-            optional: true
-        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -107,3 +105,23 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        {{- if .Values.volumes }}
+          {{- toYaml .Values.volumes | nindent 8 }}
+        {{- end }}
+        {{- if .Values.ephemeralTmp.enabled }}
+        - name: {{ .Values.ephemeralTmp.volumeMount.name | quote }}
+          {{- /* Check if emptyDir config exists, otherwise provide a default empty one */}}
+          {{- if .Values.ephemeralTmp.volume.emptyDir }}
+          emptyDir:
+            {{- toYaml .Values.ephemeralTmp.volume.emptyDir | nindent 12 }}
+          {{- else }}
+          emptyDir: {} # Default emptyDir if no specific config
+          {{- end }}
+        {{- end }}
+        {{- if $.Values.aws.licenseConfigSecretName }}
+        - name: awsmp-product-license
+          secret:
+            secretName: {{ $.Values.aws.licenseConfigSecretName }}
+            optional: true
+        {{- end }}

--- a/charts/kpow-annual/templates/deployment.yaml
+++ b/charts/kpow-annual/templates/deployment.yaml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kpow.fullname" . }}
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "kpow.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "kpow.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "kpow.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "kpow.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          {{- with .Values.env }}
+            {{- range $key, $val := . }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+          {{- end }}
+            {{- if $.Values.aws.licenseConfigSecretName }}
+            - name: AWS_WEB_IDENTITY_REFRESH_TOKEN_FILE
+              value: "/var/run/secrets/product-license/license_token"
+            - name: AWS_ROLE_ARN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.aws.licenseConfigSecretName }}
+                  key: iam_role
+            {{- end }}
+          envFrom:
+            {{- with .Values.envFromConfigMap }}
+            - configMapRef:
+                name: {{ . }}
+            {{- end }}
+            {{- with .Values.envFromSecret }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          volumeMounts:
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if $.Values.aws.licenseConfigSecretName }}
+            - name: awsmp-product-license
+              mountPath: "/var/run/secrets/product-license"
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /up
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /healthy
+              port: http
+            initialDelaySeconds: 120
+            periodSeconds: 30
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if $.Values.aws.licenseConfigSecretName }}
+        - name: awsmp-product-license
+          secret:
+            secretName: {{ $.Values.aws.licenseConfigSecretName }}
+            optional: true
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/kpow-annual/templates/hpa.yaml
+++ b/charts/kpow-annual/templates/hpa.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "kpow.fullname" . }}
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "kpow.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "kpow.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/charts/kpow-annual/templates/ingress.yaml
+++ b/charts/kpow-annual/templates/ingress.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "kpow.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $pathType := .Values.ingress.pathType -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
+apiVersion: extensions/v1beta1
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: networking.k8s.io/v1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "kpow.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+    {{- else -}}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            pathType: {{ $pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/kpow-annual/templates/service.yaml
+++ b/charts/kpow-annual/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kpow.fullname" . }}
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "kpow.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "kpow.selectorLabels" . | nindent 4 }}

--- a/charts/kpow-annual/templates/serviceaccount.yaml
+++ b/charts/kpow-annual/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kpow.serviceAccountName" . }}
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "kpow.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/kpow-annual/values.schema.json
+++ b/charts/kpow-annual/values.schema.json
@@ -1,0 +1,223 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "affinity": {
+            "type": "object"
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "maxReplicas": {
+                    "type": "integer"
+                },
+                "minReplicas": {
+                    "type": "integer"
+                },
+                "targetCPUUtilizationPercentage": {
+                    "type": "integer"
+                },
+                "targetMemoryUtilizationPercentage": {
+                    "type": "integer"
+                }
+            }
+        },
+        "aws": {
+            "type": "object",
+            "properties": {
+                "licenseConfigSecretName": {
+                    "type": "string"
+                }
+            }
+        },
+        "env": {
+            "type": "object"
+        },
+        "envFromConfigMap": {
+            "type": ["string", "null"]
+        },
+        "envFromSecret": {
+            "type": ["string", "null"]
+        },
+        "ephemeralTmp": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "volume": {
+                    "type": "object",
+                    "properties": {
+                        "emptyDir": {
+                            "type": "object",
+                            "properties": {
+                                "medium": {
+                                    "type": "string"
+                                },
+                                "sizeLimit": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "volumeMount": {
+                    "type": "object",
+                    "properties": {
+                        "mountPath": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                }
+            }
+        },
+        "imagePullSecrets": {
+            "type": "array"
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "hosts": {
+                    "type": "array"
+                },
+                "ingressClassName": {
+                    "type": "string"
+                },
+                "tls": {
+                    "type": "array"
+                }
+            }
+        },
+        "labels": {
+            "type": "object"
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "nodeSelector": {
+            "type": "object"
+        },
+        "podAnnotations": {
+            "type": "object"
+        },
+        "podSecurityContext": {
+            "type": "object"
+        },
+        "replicaCount": {
+            "type": "integer"
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "properties": {
+                        "cpu": { "type": ["integer", "string"] },
+                        "memory": { "type": ["integer", "string"] }
+                    }
+                },
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "cpu": { "type": ["integer", "string"] },
+                        "memory": { "type": ["integer", "string"] }
+                    }
+                }
+            }
+        },
+        "securityContext": {
+            "type": "object",
+            "properties": {
+                "allowPrivilegeEscalation": {
+                    "type": "boolean"
+                },
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "privileged": {
+                    "type": "boolean"
+                },
+                "runAsNonRoot": {
+                    "type": "boolean"
+                },
+                "runAsUser": {
+                    "type": "integer"
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "port": {
+                    "type": "integer"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "tolerations": {
+            "type": "array"
+        },
+        "volumeMounts": {
+            "type": "array"
+        },
+        "volumes": {
+            "type": "array"
+        }
+    }
+}

--- a/charts/kpow-annual/values.yaml
+++ b/charts/kpow-annual/values.yaml
@@ -23,6 +23,18 @@ volumes: []
 #   configMap:
 #     name: "my-kpow-config"
 
+ephemeralTmp:
+  # Sets up an emptyDir volume mount for Snappy compression and other features requiring /tmp access.
+  # Enable this if you use Snappy compression and you have readOnly filesystem Pod policies.
+  enabled: false
+  volumeMount:
+    name: "fh-tmp"
+    mountPath: "/opt/factorhouse/tmp"
+  volume:
+    emptyDir:
+      medium: Memory # Optional: for better performance
+      sizeLimit: "100Mi" # Configurable size
+
 serviceAccount:
   create: true
   annotations: {}
@@ -32,7 +44,14 @@ podAnnotations: {}
 
 podSecurityContext: {}
 
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
+  privileged: false
+  runAsNonRoot: true
+  runAsUser: 1001
+  capabilities:
+    drop:
+      - ALL
 
 service:
   enabled: true
@@ -73,3 +92,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+labels: { }

--- a/charts/kpow-annual/values.yaml
+++ b/charts/kpow-annual/values.yaml
@@ -1,0 +1,75 @@
+replicaCount: 1
+
+image:
+  repository: 709825985650.dkr.ecr.us-east-1.amazonaws.com/factor-house/kpow-annual
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+aws:
+  licenseConfigSecretName: ""
+
+env: {}
+envFromConfigMap: null
+envFromSecret: null
+volumeMounts: []
+# - name: rbac-config
+#   mountPath: /path/to/rbac-config.yaml
+#   subPath: rbac-config.yaml
+volumes: []
+# - name: rbac-config
+#   configMap:
+#     name: "my-kpow-config"
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: kpow
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  enabled: true
+  annotations: {}
+  type: ClusterIP
+  port: 3000
+
+ingress:
+  enabled: false
+  annotations: {}
+  hosts: []
+  tls: []
+  ingressClassName: ""
+
+# We recommend running Kpow w/ Guaranteed QOS
+# The default resource limit/requests are suitable for a multi-cluster installation (up to 12 Kafka Clusters + Connect + Schema).
+# For a smaller installation (up to 6 clusters) you can modify to 1CPU, 4GB heap, monitor performance afterwards and adjust as necessary.
+# For a single cluster you can modify to 0.5CPU, 2GB heap, monitor performance afterwards and adjust as necessary.
+# These resources also depend on the size of the clusters (number of brokers/topics/groups in particular).
+# The default settings are suitable for even the largest single cluster installation. For tuning assistance contact support@factorhouse.io
+resources:
+  limits:
+    cpu: 2
+    memory: 8Gi
+  requests:
+    cpu: 2
+    memory: 8Gi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 1
+  targetCPUUtilizationPercentage: 85
+  targetMemoryUtilizationPercentage: 85
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/kpow-ce/values.schema.json
+++ b/charts/kpow-ce/values.schema.json
@@ -149,6 +149,17 @@
                 "allowPrivilegeEscalation": {
                     "type": "boolean"
                 },
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
                 "privileged": {
                     "type": "boolean"
                 },

--- a/charts/kpow/templates/deployment.yaml
+++ b/charts/kpow/templates/deployment.yaml
@@ -43,6 +43,7 @@ spec:
               value: {{ $val | quote }}
             {{- end }}
           {{- end }}
+          {{- if or .Values.envFromConfigMap .Values.envFromSecret }}
           envFrom:
             {{- with .Values.envFromConfigMap }}
             - configMapRef:
@@ -52,6 +53,7 @@ spec:
             - secretRef:
                 name: {{ . }}
             {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 3000

--- a/charts/kpow/values.schema.json
+++ b/charts/kpow/values.schema.json
@@ -149,6 +149,17 @@
                 "allowPrivilegeEscalation": {
                     "type": "boolean"
                 },
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
                 "privileged": {
                     "type": "boolean"
                 },


### PR DESCRIPTION
* Moved the kpow-annual-chart from the [kpow-helm-chart-lm](https://github.com/factorhouse/kpow-helm-charts-lm) repo into `charts/kpow-annual`.
* Created `values.schema.json` to enable the Values schema badge in ArtifactHub - see below.
* Updated recent configurations
  * `ephemeralTmp` (for snappy compression) - `values.yaml` and `volumeMounts` are updated
  * `securityContext` - only `values.yaml` is updated.
* Verified on an EKS cluster - [deployment script](https://github.com/factorhouse/ververica-integration/blob/main/12_factorhouse-products-mkt.sh).

@wavejumper 
* The chart releaser step is configured to skip existing versions. It is necessary to deploy the kpow annual chart with the latest version. If it can be an issue, we can comment out the following section.

  ```
        - name: Run chart-releaser #this is used to generate new version of helm chart along with some file with extension .prov
          uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 #v1.6.0
          with:
            skip_existing: true # <---------------
          env:
            CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
            CR_KEY: "${{ secrets.CR_KEY }}" # Key name used while creating key
            CR_SIGN: true # Set to true to sign images
  ```
* Can you please raise an issue to claim the official status badge?

<img width="1796" height="623" alt="image" src="https://github.com/user-attachments/assets/7451ca07-d6ae-4141-a20e-683696a451d3" />
