### PR TITLE
Add automountServiceAccountToken value and default to false

### DIFF
--- a/charts/flex-ce/templates/deployment.yaml
+++ b/charts/flex-ce/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "flex-ce.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/flex-ce/values.schema.json
+++ b/charts/flex-ce/values.schema.json
@@ -167,6 +167,9 @@
                 }
             }
         },
+        "automountServiceAccountToken": {
+            "type": "boolean"
+        },
         "tolerations": {
             "type": "array"
         },

--- a/charts/flex-ce/values.yaml
+++ b/charts/flex-ce/values.yaml
@@ -25,6 +25,10 @@ serviceAccount:
   annotations: {}
   name: flex-ce
 
+# Controls if the K8s API token should be mounted in the pod.
+# It is set on the Pod to ensure enforcement.
+automountServiceAccountToken: false
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/charts/flex/templates/deployment.yaml
+++ b/charts/flex/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "flex.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/flex/values.schema.json
+++ b/charts/flex/values.schema.json
@@ -167,6 +167,9 @@
                 }
             }
         },
+        "automountServiceAccountToken": {
+            "type": "boolean"
+        },
         "tolerations": {
             "type": "array"
         },

--- a/charts/flex/values.yaml
+++ b/charts/flex/values.yaml
@@ -25,6 +25,10 @@ serviceAccount:
   annotations: {}
   name: flex
 
+# Controls if the K8s API token should be mounted in the pod.
+# It is set on the Pod to ensure enforcement.
+automountServiceAccountToken: false
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/charts/kpow-aws-annual/templates/deployment.yaml
+++ b/charts/kpow-aws-annual/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "kpow.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/kpow-aws-annual/values.schema.json
+++ b/charts/kpow-aws-annual/values.schema.json
@@ -210,6 +210,9 @@
                 }
             }
         },
+        "automountServiceAccountToken": {
+            "type": "boolean"
+        },
         "tolerations": {
             "type": "array"
         },

--- a/charts/kpow-aws-annual/values.yaml
+++ b/charts/kpow-aws-annual/values.yaml
@@ -40,6 +40,10 @@ serviceAccount:
   annotations: {}
   name: kpow
 
+# Controls if the K8s API token should be mounted in the pod.
+# It is set on the Pod to ensure enforcement.
+automountServiceAccountToken: false
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/charts/kpow-aws-hourly/templates/deployment.yaml
+++ b/charts/kpow-aws-hourly/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "kpow.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/kpow-aws-hourly/values.schema.json
+++ b/charts/kpow-aws-hourly/values.schema.json
@@ -202,6 +202,9 @@
                 }
             }
         },
+        "automountServiceAccountToken": {
+            "type": "boolean"
+        },
         "tolerations": {
             "type": "array"
         },

--- a/charts/kpow-aws-hourly/values.yaml
+++ b/charts/kpow-aws-hourly/values.yaml
@@ -37,6 +37,10 @@ serviceAccount:
   annotations: { }
   name: kpow
 
+# Controls if the K8s API token should be mounted in the pod.
+# It is set on the Pod to ensure enforcement.
+automountServiceAccountToken: false
+
 podAnnotations: { }
 
 podSecurityContext: { }

--- a/charts/kpow-ce/templates/deployment.yaml
+++ b/charts/kpow-ce/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "kpow-ce.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/kpow-ce/values.schema.json
+++ b/charts/kpow-ce/values.schema.json
@@ -202,6 +202,9 @@
                 }
             }
         },
+        "automountServiceAccountToken": {
+            "type": "boolean"
+        },
         "tolerations": {
             "type": "array"
         },

--- a/charts/kpow-ce/values.yaml
+++ b/charts/kpow-ce/values.yaml
@@ -37,6 +37,10 @@ serviceAccount:
   annotations: { }
   name: kpow-ce
 
+# Controls if the K8s API token should be mounted in the pod.
+# It is set on the Pod to ensure enforcement.
+automountServiceAccountToken: false
+
 podAnnotations: { }
 
 podSecurityContext: { }

--- a/charts/kpow/templates/deployment.yaml
+++ b/charts/kpow/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "kpow.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/kpow/values.schema.json
+++ b/charts/kpow/values.schema.json
@@ -202,6 +202,9 @@
                 }
             }
         },
+        "automountServiceAccountToken": {
+            "type": "boolean"
+        },
         "tolerations": {
             "type": "array"
         },

--- a/charts/kpow/values.yaml
+++ b/charts/kpow/values.yaml
@@ -37,6 +37,10 @@ serviceAccount:
   annotations: { }
   name: kpow
 
+# Controls if the K8s API token should be mounted in the pod.
+# It is set on the Pod to ensure enforcement.
+automountServiceAccountToken: false
+
 podAnnotations: { }
 
 podSecurityContext: { }


### PR DESCRIPTION
It is to disable automatic mount of the service account credential token. It doesn't affect the IAM Permissions on EKS (IRSA).

https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting

https://linear.app/factor-house/issue/FAC-823/disabling-automount-of-api-credentials