### PR TITLE
Enable api on kpow/flex enterprise editions

### DIFF
--- a/charts/flex-ce/Chart.yaml
+++ b/charts/flex-ce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flex-ce
 description: Run Flex for Apache Flink Community Edition in Kubernetes
 type: application
-version: 1.0.72
+version: 1.0.73
 appVersion: "95.1"
 keywords:
   - flink

--- a/charts/flex/Chart.yaml
+++ b/charts/flex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flex
 description: Run Flex for Apache Flink in Kubernetes
 type: application
-version: 1.0.72
+version: 1.0.73
 appVersion: "95.1"
 keywords:
   - flink

--- a/charts/flex/templates/deployment.yaml
+++ b/charts/flex/templates/deployment.yaml
@@ -55,8 +55,13 @@ spec:
             {{- end }}
           ports:
             - name: http
-              containerPort: 3000
+              containerPort: {{ .Values.service.port }}
               protocol: TCP
+            {{- if .Values.api.enabled }}
+            - name: api
+              containerPort: {{ .Values.api.port }}
+              protocol: TCP
+            {{- end }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/charts/flex/templates/ingress-api.yaml
+++ b/charts/flex/templates/ingress-api.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.ingressApi.enabled -}}
+{{- $fullName := include "flex.fullname" . -}}
+{{- $apiPort := .Values.api.port -}}
+{{- $pathType := .Values.ingressApi.pathType -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
+apiVersion: extensions/v1beta1
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: networking.k8s.io/v1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-api
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "flex.labels" . | nindent 4 }}
+  {{- with .Values.ingressApi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingressApi.ingressClassName }}
+  {{- if .Values.ingressApi.tls }}
+  tls:
+    {{- range .Values.ingressApi.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
+    {{- range .Values.ingressApi.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $apiPort }}
+          {{- end }}
+    {{- end }}
+    {{- else -}}
+    {{- range .Values.ingressApi.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            pathType: {{ $pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $apiPort }}
+          {{- end }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/flex/templates/service.yaml
+++ b/charts/flex/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,5 +17,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.api.enabled }}
+    - port: {{ .Values.api.port }}
+      targetPort: api
+      protocol: TCP
+      name: api
+    {{- end }}
   selector:
     {{- include "flex.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/charts/flex/values.schema.json
+++ b/charts/flex/values.schema.json
@@ -5,6 +5,17 @@
         "affinity": {
             "type": "object"
         },
+        "api": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "port": {
+                    "type": "integer"
+                }
+            }
+        },
         "autoscaling": {
             "type": "object",
             "properties": {
@@ -64,6 +75,32 @@
                     "type": "array"
                 },
                 "ingressClassName": {
+                    "type": "string"
+                },
+                "pathType": {
+                    "type": "string"
+                },
+                "tls": {
+                    "type": "array"
+                }
+            }
+        },
+        "ingressApi": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "hosts": {
+                    "type": "array"
+                },
+                "ingressClassName": {
+                    "type": "string"
+                },
+                "pathType": {
                     "type": "string"
                 },
                 "tls": {

--- a/charts/flex/values.yaml
+++ b/charts/flex/values.yaml
@@ -48,12 +48,47 @@ service:
   type: ClusterIP
   port: 3000
 
+api:
+  enabled: false
+  port: 3001
+
 ingress:
   enabled: false
-  annotations: {}
-  hosts: []
-  tls: []
   ingressClassName: ""
+  # The pathType for the UI paths defined below.
+  # Valid values are: Prefix, Exact, ImplementationSpecific.
+  pathType: Prefix
+  tls: []
+  # Example TLS configuration:
+  # - secretName: kpow-tls
+  #   hosts:
+  #     - kpow.example.com
+  annotations: {}
+  # Host-based routing rules for the Ingress.
+  hosts: []
+  # Example host configuration with a specific hostname:
+  # - host: kpow.example.com
+  #   paths:
+  #     - /
+
+ingressApi:
+  enabled: false
+  ingressClassName: ""
+  # The pathType for the UI paths defined below.
+  # Valid values are: Prefix, Exact, ImplementationSpecific.
+  pathType: Prefix
+  tls: []
+  # Example TLS configuration:
+  # - secretName: kpow-tls
+  #   hosts:
+  #     - kpow-api.example.com
+  annotations: {}
+  # Host-based routing rules for the Ingress.
+  hosts: []
+  # Example host configuration with a specific hostname:
+  # - host: kpow-api.example.com
+  #   paths:
+  #     - /
 
 # We recommend running Flex w/ Guaranteed QOS
 # The default resource limit/requests are suitable for a multi-cluster installation

--- a/charts/kpow-aws-annual/templates/deployment.yaml
+++ b/charts/kpow-aws-annual/templates/deployment.yaml
@@ -66,8 +66,13 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 3000
+              containerPort: {{ .Values.service.port }}
               protocol: TCP
+            {{- if .Values.api.enabled }}
+            - name: api
+              containerPort: {{ .Values.api.port }}
+              protocol: TCP
+            {{- end }}
           volumeMounts:
             {{- if .Values.volumeMounts }}
               {{- toYaml .Values.volumeMounts | nindent 12 }}

--- a/charts/kpow-aws-annual/templates/ingress-api.yaml
+++ b/charts/kpow-aws-annual/templates/ingress-api.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.ingressApi.enabled -}}
+{{- $fullName := include "kpow.fullname" . -}}
+{{- $apiPort := .Values.api.port -}}
+{{- $pathType := .Values.ingressApi.pathType -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
+apiVersion: extensions/v1beta1
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: networking.k8s.io/v1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-api
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "kpow.labels" . | nindent 4 }}
+  {{- with .Values.ingressApi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingressApi.ingressClassName }}
+  {{- if .Values.ingressApi.tls }}
+  tls:
+    {{- range .Values.ingressApi.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
+    {{- range .Values.ingressApi.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $apiPort }}
+          {{- end }}
+    {{- end }}
+    {{- else -}}
+    {{- range .Values.ingressApi.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            pathType: {{ $pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $apiPort }}
+          {{- end }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/kpow-aws-annual/templates/service.yaml
+++ b/charts/kpow-aws-annual/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,5 +17,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.api.enabled }}
+    - port: {{ .Values.api.port }}
+      targetPort: api
+      protocol: TCP
+      name: api
+    {{- end }}
   selector:
     {{- include "kpow.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/charts/kpow-aws-annual/values.schema.json
+++ b/charts/kpow-aws-annual/values.schema.json
@@ -5,6 +5,17 @@
         "affinity": {
             "type": "object"
         },
+        "api": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "port": {
+                    "type": "integer"
+                }
+            }
+        },
         "autoscaling": {
             "type": "object",
             "properties": {
@@ -107,6 +118,32 @@
                     "type": "array"
                 },
                 "ingressClassName": {
+                    "type": "string"
+                },
+                "pathType": {
+                    "type": "string"
+                },
+                "tls": {
+                    "type": "array"
+                }
+            }
+        },
+        "ingressApi": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "hosts": {
+                    "type": "array"
+                },
+                "ingressClassName": {
+                    "type": "string"
+                },
+                "pathType": {
                     "type": "string"
                 },
                 "tls": {

--- a/charts/kpow-aws-annual/values.yaml
+++ b/charts/kpow-aws-annual/values.yaml
@@ -64,12 +64,47 @@ service:
   type: ClusterIP
   port: 3000
 
+api:
+  enabled: false
+  port: 3001
+
 ingress:
   enabled: false
-  annotations: {}
-  hosts: []
-  tls: []
   ingressClassName: ""
+  # The pathType for the UI paths defined below.
+  # Valid values are: Prefix, Exact, ImplementationSpecific.
+  pathType: Prefix
+  tls: []
+  # Example TLS configuration:
+  # - secretName: kpow-tls
+  #   hosts:
+  #     - kpow.example.com
+  annotations: {}
+  # Host-based routing rules for the Ingress.
+  hosts: []
+  # Example host configuration with a specific hostname:
+  # - host: kpow.example.com
+  #   paths:
+  #     - /
+
+ingressApi:
+  enabled: false
+  ingressClassName: ""
+  # The pathType for the UI paths defined below.
+  # Valid values are: Prefix, Exact, ImplementationSpecific.
+  pathType: Prefix
+  tls: []
+  # Example TLS configuration:
+  # - secretName: kpow-tls
+  #   hosts:
+  #     - kpow-api.example.com
+  annotations: {}
+  # Host-based routing rules for the Ingress.
+  hosts: []
+  # Example host configuration with a specific hostname:
+  # - host: kpow-api.example.com
+  #   paths:
+  #     - /
 
 # We recommend running Kpow w/ Guaranteed QOS
 # The default resource limit/requests are suitable for a multi-cluster installation (up to 12 Kafka Clusters + Connect + Schema).

--- a/charts/kpow-aws-hourly/templates/deployment.yaml
+++ b/charts/kpow-aws-hourly/templates/deployment.yaml
@@ -57,8 +57,13 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 3000
+              containerPort: {{ .Values.service.port }}
               protocol: TCP
+            {{- if .Values.api.enabled }}
+            - name: api
+              containerPort: {{ .Values.api.port }}
+              protocol: TCP
+            {{- end }}
           {{- if or .Values.volumeMounts .Values.ephemeralTmp.enabled }}
           volumeMounts:
             {{- if .Values.volumeMounts }}

--- a/charts/kpow-aws-hourly/templates/ingress-api.yaml
+++ b/charts/kpow-aws-hourly/templates/ingress-api.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.ingressApi.enabled -}}
+{{- $fullName := include "kpow.fullname" . -}}
+{{- $apiPort := .Values.api.port -}}
+{{- $pathType := .Values.ingressApi.pathType -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
+apiVersion: extensions/v1beta1
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: networking.k8s.io/v1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-api
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "kpow.labels" . | nindent 4 }}
+  {{- with .Values.ingressApi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingressApi.ingressClassName }}
+  {{- if .Values.ingressApi.tls }}
+  tls:
+    {{- range .Values.ingressApi.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
+    {{- range .Values.ingressApi.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $apiPort }}
+          {{- end }}
+    {{- end }}
+    {{- else -}}
+    {{- range .Values.ingressApi.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            pathType: {{ $pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $apiPort }}
+          {{- end }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/kpow-aws-hourly/templates/service.yaml
+++ b/charts/kpow-aws-hourly/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,5 +17,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.api.enabled }}
+    - port: {{ .Values.api.port }}
+      targetPort: api
+      protocol: TCP
+      name: api
+    {{- end }}
   selector:
     {{- include "kpow.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/charts/kpow-aws-hourly/values.schema.json
+++ b/charts/kpow-aws-hourly/values.schema.json
@@ -5,6 +5,17 @@
         "affinity": {
             "type": "object"
         },
+        "api": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "port": {
+                    "type": "integer"
+                }
+            }
+        },
         "autoscaling": {
             "type": "object",
             "properties": {
@@ -99,6 +110,32 @@
                     "type": "array"
                 },
                 "ingressClassName": {
+                    "type": "string"
+                },
+                "pathType": {
+                    "type": "string"
+                },
+                "tls": {
+                    "type": "array"
+                }
+            }
+        },
+        "ingressApi": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "hosts": {
+                    "type": "array"
+                },
+                "ingressClassName": {
+                    "type": "string"
+                },
+                "pathType": {
                     "type": "string"
                 },
                 "tls": {

--- a/charts/kpow-aws-hourly/values.yaml
+++ b/charts/kpow-aws-hourly/values.yaml
@@ -56,16 +56,51 @@ securityContext:
 
 service:
   enabled: true
-  annotations: { }
+  annotations: {}
   type: ClusterIP
   port: 3000
 
+api:
+  enabled: false
+  port: 3001
+
 ingress:
   enabled: false
-  annotations: { }
-  hosts: [ ]
-  tls: [ ]
   ingressClassName: ""
+  # The pathType for the UI paths defined below.
+  # Valid values are: Prefix, Exact, ImplementationSpecific.
+  pathType: Prefix
+  tls: []
+  # Example TLS configuration:
+  # - secretName: kpow-tls
+  #   hosts:
+  #     - kpow.example.com
+  annotations: {}
+  # Host-based routing rules for the Ingress.
+  hosts: []
+  # Example host configuration with a specific hostname:
+  # - host: kpow.example.com
+  #   paths:
+  #     - /
+
+ingressApi:
+  enabled: false
+  ingressClassName: ""
+  # The pathType for the UI paths defined below.
+  # Valid values are: Prefix, Exact, ImplementationSpecific.
+  pathType: Prefix
+  tls: []
+  # Example TLS configuration:
+  # - secretName: kpow-tls
+  #   hosts:
+  #     - kpow-api.example.com
+  annotations: {}
+  # Host-based routing rules for the Ingress.
+  hosts: []
+  # Example host configuration with a specific hostname:
+  # - host: kpow-api.example.com
+  #   paths:
+  #     - /
 
 # We recommend running Kpow w/ Guaranteed QOS
 # The default resource limit/requests are suitable for a multi-cluster installation (up to 12 Kafka Clusters + Connect + Schema).

--- a/charts/kpow-ce/Chart.yaml
+++ b/charts/kpow-ce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kpow-ce
 description: Run Kpow for Apache Kafka Community Edition in Kubernetes
 type: application
-version: 1.0.72
+version: 1.0.73
 appVersion: "95.1"
 keywords:
   - kafka

--- a/charts/kpow/Chart.yaml
+++ b/charts/kpow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kpow
 description: Run Kpow for Apache Kafka in Kubernetes
 type: application
-version: 1.0.72
+version: 1.0.73
 appVersion: "95.1"
 keywords:
   - kafka

--- a/charts/kpow/templates/deployment.yaml
+++ b/charts/kpow/templates/deployment.yaml
@@ -57,8 +57,13 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 3000
+              containerPort: {{ .Values.service.port }}
               protocol: TCP
+            {{- if .Values.api.enabled }}
+            - name: api
+              containerPort: {{ .Values.api.port }}
+              protocol: TCP
+            {{- end }}
           {{- if or .Values.volumeMounts .Values.ephemeralTmp.enabled }}
           volumeMounts:
             {{- if .Values.volumeMounts }}

--- a/charts/kpow/templates/ingress-api.yaml
+++ b/charts/kpow/templates/ingress-api.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.ingressApi.enabled -}}
+{{- $fullName := include "kpow.fullname" . -}}
+{{- $apiPort := .Values.api.port -}}
+{{- $pathType := .Values.ingressApi.pathType -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
+apiVersion: extensions/v1beta1
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: networking.k8s.io/v1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-api
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "kpow.labels" . | nindent 4 }}
+  {{- with .Values.ingressApi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingressApi.ingressClassName }}
+  {{- if .Values.ingressApi.tls }}
+  tls:
+    {{- range .Values.ingressApi.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
+    {{- range .Values.ingressApi.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $apiPort }}
+          {{- end }}
+    {{- end }}
+    {{- else -}}
+    {{- range .Values.ingressApi.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            pathType: {{ $pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $apiPort }}
+          {{- end }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/kpow/templates/service.yaml
+++ b/charts/kpow/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,5 +17,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.api.enabled }}
+    - port: {{ .Values.api.port }}
+      targetPort: api
+      protocol: TCP
+      name: api
+    {{- end }}
   selector:
     {{- include "kpow.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/charts/kpow/values.schema.json
+++ b/charts/kpow/values.schema.json
@@ -5,6 +5,17 @@
         "affinity": {
             "type": "object"
         },
+        "api": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "port": {
+                    "type": "integer"
+                }
+            }
+        },
         "autoscaling": {
             "type": "object",
             "properties": {
@@ -101,6 +112,32 @@
                 "ingressClassName": {
                     "type": "string"
                 },
+                "pathType": {
+                    "type": "string"
+                },
+                "tls": {
+                    "type": "array"
+                }
+            }
+        },
+        "ingressApi": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "hosts": {
+                    "type": "array"
+                },
+                "ingressClassName": {
+                    "type": "string"
+                },
+                "pathType": {
+                    "type": "string"
+                },
                 "tls": {
                     "type": "array"
                 }
@@ -171,7 +208,7 @@
                 }
             }
         },
-        "service": {
+       "service": {
             "type": "object",
             "properties": {
                 "annotations": {

--- a/charts/kpow/values.yaml
+++ b/charts/kpow/values.yaml
@@ -56,16 +56,51 @@ securityContext:
 
 service:
   enabled: true
-  annotations: { }
+  annotations: {}
   type: ClusterIP
   port: 3000
 
+api:
+  enabled: false
+  port: 3001
+
 ingress:
   enabled: false
-  annotations: { }
-  hosts: [ ]
-  tls: [ ]
   ingressClassName: ""
+  # The pathType for the UI paths defined below.
+  # Valid values are: Prefix, Exact, ImplementationSpecific.
+  pathType: Prefix
+  tls: []
+  # Example TLS configuration:
+  # - secretName: kpow-tls
+  #   hosts:
+  #     - kpow.example.com
+  annotations: {}
+  # Host-based routing rules for the Ingress.
+  hosts: []
+  # Example host configuration with a specific hostname:
+  # - host: kpow.example.com
+  #   paths:
+  #     - /
+
+ingressApi:
+  enabled: false
+  ingressClassName: ""
+  # The pathType for the UI paths defined below.
+  # Valid values are: Prefix, Exact, ImplementationSpecific.
+  pathType: Prefix
+  tls: []
+  # Example TLS configuration:
+  # - secretName: kpow-tls
+  #   hosts:
+  #     - kpow-api.example.com
+  annotations: {}
+  # Host-based routing rules for the Ingress.
+  hosts: []
+  # Example host configuration with a specific hostname:
+  # - host: kpow-api.example.com
+  #   paths:
+  #     - /
 
 # We recommend running Kpow w/ Guaranteed QOS
 # The default resource limit/requests are suitable for a multi-cluster installation (up to 12 Kafka Clusters + Connect + Schema).


### PR DESCRIPTION
Enable API on Kpow/Flex EE.
- If API is enabled, a new port (default 3001) is exposed.
- A separate ingress is created, which serves the API in a different hostname
  - Serving from the same hostname requires complicated rewrite rules and the rules are different from each ingress controller

Update value configurations.

```
service:
  enabled: true
  annotations: {}
  type: ClusterIP
  port: 3000

api:
  enabled: false
  port: 3001

ingress:
  enabled: false
  ingressClassName: ""
  # The pathType for the UI paths defined below.
  # Valid values are: Prefix, Exact, ImplementationSpecific.
  pathType: Prefix
  tls: []
  # Example TLS configuration:
  # - secretName: kpow-tls
  #   hosts:
  #     - kpow.example.com
  annotations: {}
  # Host-based routing rules for the Ingress.
  hosts: []
  # Example host configuration with a specific hostname:
  # - host: kpow.example.com
  #   paths:
  #     - /

ingressApi:
  enabled: false
  ingressClassName: ""
  # The pathType for the UI paths defined below.
  # Valid values are: Prefix, Exact, ImplementationSpecific.
  pathType: Prefix
  tls: []
  # Example TLS configuration:
  # - secretName: kpow-tls
  #   hosts:
  #     - kpow-api.example.com
  annotations: {}
  # Host-based routing rules for the Ingress.
  hosts: []
  # Example host configuration with a specific hostname:
  # - host: kpow-api.example.com
  #   paths:
  #     - /
```