### PR TITLE
Bump up versions for 95.4 release

### DIFF
--- a/charts/flex-ce/Chart.yaml
+++ b/charts/flex-ce/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: flex-ce
 description: Run Flex for Apache Flink Community Edition in Kubernetes
 type: application
-version: 1.0.75
-appVersion: "95.3"
+version: 1.0.76
+appVersion: "95.4"
 keywords:
   - flink
   - flink-ui

--- a/charts/flex/Chart.yaml
+++ b/charts/flex/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: flex
 description: Run Flex for Apache Flink in Kubernetes
 type: application
-version: 1.0.75
-appVersion: "95.3"
+version: 1.0.76
+appVersion: "95.4"
 keywords:
   - flink
   - flink-ui

--- a/charts/kpow-aws-annual/Chart.yaml
+++ b/charts/kpow-aws-annual/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kpow-aws-annual
 description: Run Kpow Annual from the AWS Marketplace in Kubernetes
 type: application
-version: 1.0.69
-appVersion: "95.3"
+version: 1.0.70
+appVersion: "95.4"
 keywords:
   - kafka
   - kafka-ui

--- a/charts/kpow-aws-annual/values.yaml
+++ b/charts/kpow-aws-annual/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: 709825985650.dkr.ecr.us-east-1.amazonaws.com/factor-house/kpow-annual
   pullPolicy: IfNotPresent
-  tag: "95.3"
+  tag: "95.4"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/kpow-aws-hourly/Chart.yaml
+++ b/charts/kpow-aws-hourly/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kpow-aws-hourly
 description: Run Kpow Hourly from the AWS Marketplace in Kubernetes
 type: application
-version: 1.0.05
-appVersion: "95.3"
+version: 1.0.06
+appVersion: "95.4"
 keywords:
   - kafka
   - kafka-ui

--- a/charts/kpow-ce/Chart.yaml
+++ b/charts/kpow-ce/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kpow-ce
 description: Run Kpow for Apache Kafka Community Edition in Kubernetes
 type: application
-version: 1.0.75
-appVersion: "95.3"
+version: 1.0.76
+appVersion: "95.4"
 keywords:
   - kafka
   - kafka-ui

--- a/charts/kpow/Chart.yaml
+++ b/charts/kpow/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kpow
 description: Run Kpow for Apache Kafka in Kubernetes
 type: application
-version: 1.0.75
-appVersion: "95.3"
+version: 1.0.77
+appVersion: "95.4"
 keywords:
   - kafka
   - kafka-ui


### PR DESCRIPTION
Note Kpow chart's version is 1.0.76 while others are 1.0.75 currently. Their versions no longer match.
- https://artifacthub.io/packages/search?ts_query_web=factor+house&sort=relevance&page=1