### PR TITLE
Add gateway and gatewayApi opts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .vscode
+*.iml

--- a/charts/factor-platform/templates/NOTES.txt
+++ b/charts/factor-platform/templates/NOTES.txt
@@ -5,6 +5,12 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
   {{- end }}
 {{- end }}
+{{- else if .Values.gateway.enabled }}
+{{- range $host := .Values.gateway.hosts }}
+  {{- range .paths }}
+  http://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "platform.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
@@ -18,4 +24,21 @@
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "platform.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:3000 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 3000:3000
+{{- end }}
+{{- if or .Values.ingressApi.enabled .Values.gatewayApi.enabled }}
+
+2. Get the API URL by running these commands:
+{{- if .Values.ingressApi.enabled }}
+{{- range $host := .Values.ingressApi.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingressApi.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if .Values.gatewayApi.enabled }}
+{{- range $host := .Values.gatewayApi.hosts }}
+  {{- range .paths }}
+  http://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/factor-platform/templates/gateway-api.yaml
+++ b/charts/factor-platform/templates/gateway-api.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.gatewayApi.enabled -}}
+{{- $fullName := include "platform.fullname" . -}}
+{{- $apiPort := .Values.api.port -}}
+{{- $pathType := .Values.gatewayApi.pathType -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-api
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+  {{- with .Values.gatewayApi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  - name: {{ .Values.gatewayApi.gatewayName }}
+    {{- if .Values.gatewayApi.gatewayNamespace }}
+    namespace: {{ .Values.gatewayApi.gatewayNamespace }}
+    {{- end }}
+  {{- if .Values.gatewayApi.hosts }}
+  hostnames:
+    {{- range .Values.gatewayApi.hosts }}
+    - {{ .host | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.gatewayApi.hosts }}
+    {{- range .paths }}
+    - matches:
+      - path:
+          type: {{ $pathType }}
+          value: {{ . | quote }}
+      backendRefs:
+      - name: {{ $fullName }}
+        port: {{ $apiPort }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/factor-platform/templates/gateway.yaml
+++ b/charts/factor-platform/templates/gateway.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "platform.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $pathType := .Values.gateway.pathType -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  - name: {{ .Values.gateway.gatewayName }}
+    {{- if .Values.gateway.gatewayNamespace }}
+    namespace: {{ .Values.gateway.gatewayNamespace }}
+    {{- end }}
+  {{- if .Values.gateway.hosts }}
+  hostnames:
+    {{- range .Values.gateway.hosts }}
+    - {{ .host | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.gateway.hosts }}
+    {{- range .paths }}
+    - matches:
+      - path:
+          type: {{ $pathType }}
+          value: {{ . | quote }}
+      backendRefs:
+      - name: {{ $fullName }}
+        port: {{ $svcPort }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/factor-platform/templates/ingress-api.yaml
+++ b/charts/factor-platform/templates/ingress-api.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingressApi.enabled -}}
+{{- if and .Values.ingressApi.enabled (not .Values.gatewayApi.enabled) -}}
 {{- $fullName := include "platform.fullname" . -}}
 {{- $apiPort := .Values.api.port -}}
 {{- $pathType := .Values.ingressApi.pathType -}}

--- a/charts/factor-platform/templates/ingress.yaml
+++ b/charts/factor-platform/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled (not .Values.gateway.enabled) -}}
 {{- $fullName := include "platform.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $pathType := .Values.ingress.pathType -}}

--- a/charts/factor-platform/values.yaml
+++ b/charts/factor-platform/values.yaml
@@ -104,6 +104,32 @@ ingressApi:
   #   paths:
   #     - /
 
+gateway:
+  enabled: false
+  gatewayName: ""
+  gatewayNamespace: ""
+  annotations: {}
+  # The path type for HTTPRoute matches.
+  # Valid values are: PathPrefix, Exact.
+  pathType: PathPrefix
+  hosts: []
+  # Example host configuration:
+  # - host: factor.example.com
+  #   paths:
+  #     - /
+
+gatewayApi:
+  enabled: false
+  gatewayName: ""
+  gatewayNamespace: ""
+  annotations: {}
+  pathType: PathPrefix
+  hosts: []
+  # Example host configuration:
+  # - host: factor-api.example.com
+  #   paths:
+  #     - /
+
 # We recommend running Kpow w/ Guaranteed QOS
 # The default resource limit/requests are suitable for a multi-cluster installation (up to 12 Kafka Clusters + Connect + Schema).
 # For a smaller installation (up to 6 clusters) you can modify to 1CPU, 4GB heap, monitor performance afterwards and adjust as necessary.

--- a/charts/factor-platform/values.yaml
+++ b/charts/factor-platform/values.yaml
@@ -66,6 +66,13 @@ api:
   enabled: false
   port: 3001
 
+# HTTP Gateway
+#
+# Factor Platform supports either the traditional Ingress API for basic HTTP routing capabilities or
+# the next generation Gateway API for more advanced HTTP routing.
+#
+# Only one approach (ingress or gateway) can be enabled at a time
+
 ingress:
   enabled: false
   ingressClassName: ""

--- a/charts/flex-ce/templates/NOTES.txt
+++ b/charts/flex-ce/templates/NOTES.txt
@@ -5,6 +5,12 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
   {{- end }}
 {{- end }}
+{{- else if .Values.gateway.enabled }}
+{{- range $host := .Values.gateway.hosts }}
+  {{- range .paths }}
+  http://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "flex-ce.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/flex-ce/templates/gateway.yaml
+++ b/charts/flex-ce/templates/gateway.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "flex-ce.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $pathType := .Values.gateway.pathType -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "flex-ce.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  - name: {{ .Values.gateway.gatewayName }}
+    {{- if .Values.gateway.gatewayNamespace }}
+    namespace: {{ .Values.gateway.gatewayNamespace }}
+    {{- end }}
+  {{- if .Values.gateway.hosts }}
+  hostnames:
+    {{- range .Values.gateway.hosts }}
+    - {{ .host | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.gateway.hosts }}
+    {{- range .paths }}
+    - matches:
+      - path:
+          type: {{ $pathType }}
+          value: {{ . | quote }}
+      backendRefs:
+      - name: {{ $fullName }}
+        port: {{ $svcPort }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/flex-ce/templates/ingress.yaml
+++ b/charts/flex-ce/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled (not .Values.gateway.enabled) -}}
 {{- $fullName := include "flex-ce.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $pathType := .Values.ingress.pathType -}}

--- a/charts/flex-ce/values.yaml
+++ b/charts/flex-ce/values.yaml
@@ -57,6 +57,18 @@ ingress:
   tls: []
   ingressClassName: ""
 
+gateway:
+  enabled: false
+  gatewayName: ""
+  gatewayNamespace: ""
+  annotations: {}
+  pathType: PathPrefix
+  hosts: []
+  # Example host configuration:
+  # - host: flex-ce.example.com
+  #   paths:
+  #     - /
+
 # We recommend running Flex w/ Guaranteed QOS
 # For a single cluster you can modify to 0.5CPU, 2GB heap, monitor performance afterwards and adjust as necessary.
 resources:

--- a/charts/flex/templates/NOTES.txt
+++ b/charts/flex/templates/NOTES.txt
@@ -5,6 +5,12 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
   {{- end }}
 {{- end }}
+{{- else if .Values.gateway.enabled }}
+{{- range $host := .Values.gateway.hosts }}
+  {{- range .paths }}
+  http://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "flex.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
@@ -18,4 +24,21 @@
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "flex.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:3000 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 3000:3000
+{{- end }}
+{{- if or .Values.ingressApi.enabled .Values.gatewayApi.enabled }}
+
+2. Get the API URL by running these commands:
+{{- if .Values.ingressApi.enabled }}
+{{- range $host := .Values.ingressApi.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingressApi.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if .Values.gatewayApi.enabled }}
+{{- range $host := .Values.gatewayApi.hosts }}
+  {{- range .paths }}
+  http://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/flex/templates/gateway-api.yaml
+++ b/charts/flex/templates/gateway-api.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.gatewayApi.enabled -}}
+{{- $fullName := include "flex.fullname" . -}}
+{{- $apiPort := .Values.api.port -}}
+{{- $pathType := .Values.gatewayApi.pathType -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-api
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "flex.labels" . | nindent 4 }}
+  {{- with .Values.gatewayApi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  - name: {{ .Values.gatewayApi.gatewayName }}
+    {{- if .Values.gatewayApi.gatewayNamespace }}
+    namespace: {{ .Values.gatewayApi.gatewayNamespace }}
+    {{- end }}
+  {{- if .Values.gatewayApi.hosts }}
+  hostnames:
+    {{- range .Values.gatewayApi.hosts }}
+    - {{ .host | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.gatewayApi.hosts }}
+    {{- range .paths }}
+    - matches:
+      - path:
+          type: {{ $pathType }}
+          value: {{ . | quote }}
+      backendRefs:
+      - name: {{ $fullName }}
+        port: {{ $apiPort }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/flex/templates/gateway.yaml
+++ b/charts/flex/templates/gateway.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "flex.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $pathType := .Values.gateway.pathType -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "flex.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  - name: {{ .Values.gateway.gatewayName }}
+    {{- if .Values.gateway.gatewayNamespace }}
+    namespace: {{ .Values.gateway.gatewayNamespace }}
+    {{- end }}
+  {{- if .Values.gateway.hosts }}
+  hostnames:
+    {{- range .Values.gateway.hosts }}
+    - {{ .host | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.gateway.hosts }}
+    {{- range .paths }}
+    - matches:
+      - path:
+          type: {{ $pathType }}
+          value: {{ . | quote }}
+      backendRefs:
+      - name: {{ $fullName }}
+        port: {{ $svcPort }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/flex/templates/ingress-api.yaml
+++ b/charts/flex/templates/ingress-api.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingressApi.enabled -}}
+{{- if and .Values.ingressApi.enabled (not .Values.gatewayApi.enabled) -}}
 {{- $fullName := include "flex.fullname" . -}}
 {{- $apiPort := .Values.api.port -}}
 {{- $pathType := .Values.ingressApi.pathType -}}

--- a/charts/flex/templates/ingress.yaml
+++ b/charts/flex/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled (not .Values.gateway.enabled) -}}
 {{- $fullName := include "flex.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $pathType := .Values.ingress.pathType -}}

--- a/charts/flex/values.yaml
+++ b/charts/flex/values.yaml
@@ -54,6 +54,13 @@ api:
   enabled: false
   port: 3001
 
+# HTTP Gateway
+#
+# Flex supports either the traditional Ingress API for basic HTTP routing capabilities or
+# the next generation Gateway API for more advanced HTTP routing.
+#
+# Only one approach (ingress or gateway) can be enabled at a time
+
 ingress:
   enabled: false
   ingressClassName: ""

--- a/charts/flex/values.yaml
+++ b/charts/flex/values.yaml
@@ -92,6 +92,32 @@ ingressApi:
   #   paths:
   #     - /
 
+gateway:
+  enabled: false
+  gatewayName: ""
+  gatewayNamespace: ""
+  annotations: {}
+  # The path type for HTTPRoute matches.
+  # Valid values are: PathPrefix, Exact.
+  pathType: PathPrefix
+  hosts: []
+  # Example host configuration:
+  # - host: flex.example.com
+  #   paths:
+  #     - /
+
+gatewayApi:
+  enabled: false
+  gatewayName: ""
+  gatewayNamespace: ""
+  annotations: {}
+  pathType: PathPrefix
+  hosts: []
+  # Example host configuration:
+  # - host: flex-api.example.com
+  #   paths:
+  #     - /
+
 # We recommend running Flex w/ Guaranteed QOS
 # The default resource limit/requests are suitable for a multi-cluster installation
 # For a smaller installation (up to 6 clusters) you can modify to 1CPU, 4GB heap, monitor performance afterwards and adjust as necessary.

--- a/charts/kpow-aws-annual/templates/NOTES.txt
+++ b/charts/kpow-aws-annual/templates/NOTES.txt
@@ -5,6 +5,12 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
   {{- end }}
 {{- end }}
+{{- else if .Values.gateway.enabled }}
+{{- range $host := .Values.gateway.hosts }}
+  {{- range .paths }}
+  http://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kpow.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
@@ -18,4 +24,21 @@
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kpow.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:3000 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 3000:3000
+{{- end }}
+{{- if or .Values.ingressApi.enabled .Values.gatewayApi.enabled }}
+
+2. Get the API URL by running these commands:
+{{- if .Values.ingressApi.enabled }}
+{{- range $host := .Values.ingressApi.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingressApi.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if .Values.gatewayApi.enabled }}
+{{- range $host := .Values.gatewayApi.hosts }}
+  {{- range .paths }}
+  http://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/kpow-aws-annual/templates/gateway-api.yaml
+++ b/charts/kpow-aws-annual/templates/gateway-api.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.gatewayApi.enabled -}}
+{{- $fullName := include "kpow.fullname" . -}}
+{{- $apiPort := .Values.api.port -}}
+{{- $pathType := .Values.gatewayApi.pathType -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-api
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "kpow.labels" . | nindent 4 }}
+  {{- with .Values.gatewayApi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  - name: {{ .Values.gatewayApi.gatewayName }}
+    {{- if .Values.gatewayApi.gatewayNamespace }}
+    namespace: {{ .Values.gatewayApi.gatewayNamespace }}
+    {{- end }}
+  {{- if .Values.gatewayApi.hosts }}
+  hostnames:
+    {{- range .Values.gatewayApi.hosts }}
+    - {{ .host | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.gatewayApi.hosts }}
+    {{- range .paths }}
+    - matches:
+      - path:
+          type: {{ $pathType }}
+          value: {{ . | quote }}
+      backendRefs:
+      - name: {{ $fullName }}
+        port: {{ $apiPort }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/kpow-aws-annual/templates/gateway.yaml
+++ b/charts/kpow-aws-annual/templates/gateway.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "kpow.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $pathType := .Values.gateway.pathType -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "kpow.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  - name: {{ .Values.gateway.gatewayName }}
+    {{- if .Values.gateway.gatewayNamespace }}
+    namespace: {{ .Values.gateway.gatewayNamespace }}
+    {{- end }}
+  {{- if .Values.gateway.hosts }}
+  hostnames:
+    {{- range .Values.gateway.hosts }}
+    - {{ .host | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.gateway.hosts }}
+    {{- range .paths }}
+    - matches:
+      - path:
+          type: {{ $pathType }}
+          value: {{ . | quote }}
+      backendRefs:
+      - name: {{ $fullName }}
+        port: {{ $svcPort }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/kpow-aws-annual/templates/ingress-api.yaml
+++ b/charts/kpow-aws-annual/templates/ingress-api.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingressApi.enabled -}}
+{{- if and .Values.ingressApi.enabled (not .Values.gatewayApi.enabled) -}}
 {{- $fullName := include "kpow.fullname" . -}}
 {{- $apiPort := .Values.api.port -}}
 {{- $pathType := .Values.ingressApi.pathType -}}

--- a/charts/kpow-aws-annual/templates/ingress.yaml
+++ b/charts/kpow-aws-annual/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled (not .Values.gateway.enabled) -}}
 {{- $fullName := include "kpow.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $pathType := .Values.ingress.pathType -}}

--- a/charts/kpow-aws-annual/values.yaml
+++ b/charts/kpow-aws-annual/values.yaml
@@ -70,6 +70,13 @@ api:
   enabled: false
   port: 3001
 
+# HTTP Gateway
+#
+# Kpow supports either the traditional Ingress API for basic HTTP routing capabilities or
+# the next generation Gateway API for more advanced HTTP routing.
+#
+# Only one approach (ingress or gateway) can be enabled at a time
+
 ingress:
   enabled: false
   ingressClassName: ""

--- a/charts/kpow-aws-annual/values.yaml
+++ b/charts/kpow-aws-annual/values.yaml
@@ -108,6 +108,32 @@ ingressApi:
   #   paths:
   #     - /
 
+gateway:
+  enabled: false
+  gatewayName: ""
+  gatewayNamespace: ""
+  annotations: {}
+  # The path type for HTTPRoute matches.
+  # Valid values are: PathPrefix, Exact.
+  pathType: PathPrefix
+  hosts: []
+  # Example host configuration:
+  # - host: kpow.example.com
+  #   paths:
+  #     - /
+
+gatewayApi:
+  enabled: false
+  gatewayName: ""
+  gatewayNamespace: ""
+  annotations: {}
+  pathType: PathPrefix
+  hosts: []
+  # Example host configuration:
+  # - host: kpow-api.example.com
+  #   paths:
+  #     - /
+
 # We recommend running Kpow w/ Guaranteed QOS
 # The default resource limit/requests are suitable for a multi-cluster installation (up to 12 Kafka Clusters + Connect + Schema).
 # For a smaller installation (up to 6 clusters) you can modify to 1CPU, 4GB heap, monitor performance afterwards and adjust as necessary.

--- a/charts/kpow-aws-hourly/templates/NOTES.txt
+++ b/charts/kpow-aws-hourly/templates/NOTES.txt
@@ -5,6 +5,12 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
   {{- end }}
 {{- end }}
+{{- else if .Values.gateway.enabled }}
+{{- range $host := .Values.gateway.hosts }}
+  {{- range .paths }}
+  http://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kpow.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
@@ -18,4 +24,21 @@
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kpow.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:3000 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 3000:3000
+{{- end }}
+{{- if or .Values.ingressApi.enabled .Values.gatewayApi.enabled }}
+
+2. Get the API URL by running these commands:
+{{- if .Values.ingressApi.enabled }}
+{{- range $host := .Values.ingressApi.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingressApi.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if .Values.gatewayApi.enabled }}
+{{- range $host := .Values.gatewayApi.hosts }}
+  {{- range .paths }}
+  http://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/kpow-aws-hourly/templates/gateway-api.yaml
+++ b/charts/kpow-aws-hourly/templates/gateway-api.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.gatewayApi.enabled -}}
+{{- $fullName := include "kpow.fullname" . -}}
+{{- $apiPort := .Values.api.port -}}
+{{- $pathType := .Values.gatewayApi.pathType -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-api
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "kpow.labels" . | nindent 4 }}
+  {{- with .Values.gatewayApi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  - name: {{ .Values.gatewayApi.gatewayName }}
+    {{- if .Values.gatewayApi.gatewayNamespace }}
+    namespace: {{ .Values.gatewayApi.gatewayNamespace }}
+    {{- end }}
+  {{- if .Values.gatewayApi.hosts }}
+  hostnames:
+    {{- range .Values.gatewayApi.hosts }}
+    - {{ .host | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.gatewayApi.hosts }}
+    {{- range .paths }}
+    - matches:
+      - path:
+          type: {{ $pathType }}
+          value: {{ . | quote }}
+      backendRefs:
+      - name: {{ $fullName }}
+        port: {{ $apiPort }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/kpow-aws-hourly/templates/gateway.yaml
+++ b/charts/kpow-aws-hourly/templates/gateway.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "kpow.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $pathType := .Values.gateway.pathType -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "kpow.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  - name: {{ .Values.gateway.gatewayName }}
+    {{- if .Values.gateway.gatewayNamespace }}
+    namespace: {{ .Values.gateway.gatewayNamespace }}
+    {{- end }}
+  {{- if .Values.gateway.hosts }}
+  hostnames:
+    {{- range .Values.gateway.hosts }}
+    - {{ .host | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.gateway.hosts }}
+    {{- range .paths }}
+    - matches:
+      - path:
+          type: {{ $pathType }}
+          value: {{ . | quote }}
+      backendRefs:
+      - name: {{ $fullName }}
+        port: {{ $svcPort }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/kpow-aws-hourly/templates/ingress-api.yaml
+++ b/charts/kpow-aws-hourly/templates/ingress-api.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingressApi.enabled -}}
+{{- if and .Values.ingressApi.enabled (not .Values.gatewayApi.enabled) -}}
 {{- $fullName := include "kpow.fullname" . -}}
 {{- $apiPort := .Values.api.port -}}
 {{- $pathType := .Values.ingressApi.pathType -}}

--- a/charts/kpow-aws-hourly/templates/ingress.yaml
+++ b/charts/kpow-aws-hourly/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled (not .Values.gateway.enabled) -}}
 {{- $fullName := include "kpow.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $pathType := .Values.ingress.pathType -}}

--- a/charts/kpow-aws-hourly/values.yaml
+++ b/charts/kpow-aws-hourly/values.yaml
@@ -66,6 +66,13 @@ api:
   enabled: false
   port: 3001
 
+# HTTP Gateway
+#
+# Kpow supports either the traditional Ingress API for basic HTTP routing capabilities or
+# the next generation Gateway API for more advanced HTTP routing.
+#
+# Only one approach (ingress or gateway) can be enabled at a time
+
 ingress:
   enabled: false
   ingressClassName: ""

--- a/charts/kpow-aws-hourly/values.yaml
+++ b/charts/kpow-aws-hourly/values.yaml
@@ -104,6 +104,32 @@ ingressApi:
   #   paths:
   #     - /
 
+gateway:
+  enabled: false
+  gatewayName: ""
+  gatewayNamespace: ""
+  annotations: {}
+  # The path type for HTTPRoute matches.
+  # Valid values are: PathPrefix, Exact.
+  pathType: PathPrefix
+  hosts: []
+  # Example host configuration:
+  # - host: kpow.example.com
+  #   paths:
+  #     - /
+
+gatewayApi:
+  enabled: false
+  gatewayName: ""
+  gatewayNamespace: ""
+  annotations: {}
+  pathType: PathPrefix
+  hosts: []
+  # Example host configuration:
+  # - host: kpow-api.example.com
+  #   paths:
+  #     - /
+
 # We recommend running Kpow w/ Guaranteed QOS
 # The default resource limit/requests are suitable for a multi-cluster installation (up to 12 Kafka Clusters + Connect + Schema).
 # For a smaller installation (up to 6 clusters) you can modify to 1CPU, 4GB heap, monitor performance afterwards and adjust as necessary.

--- a/charts/kpow-ce/templates/NOTES.txt
+++ b/charts/kpow-ce/templates/NOTES.txt
@@ -5,6 +5,12 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
   {{- end }}
 {{- end }}
+{{- else if .Values.gateway.enabled }}
+{{- range $host := .Values.gateway.hosts }}
+  {{- range .paths }}
+  http://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kpow-ce.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/kpow-ce/templates/gateway.yaml
+++ b/charts/kpow-ce/templates/gateway.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "kpow-ce.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $pathType := .Values.gateway.pathType -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "kpow-ce.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  - name: {{ .Values.gateway.gatewayName }}
+    {{- if .Values.gateway.gatewayNamespace }}
+    namespace: {{ .Values.gateway.gatewayNamespace }}
+    {{- end }}
+  {{- if .Values.gateway.hosts }}
+  hostnames:
+    {{- range .Values.gateway.hosts }}
+    - {{ .host | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.gateway.hosts }}
+    {{- range .paths }}
+    - matches:
+      - path:
+          type: {{ $pathType }}
+          value: {{ . | quote }}
+      backendRefs:
+      - name: {{ $fullName }}
+        port: {{ $svcPort }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/kpow-ce/templates/ingress.yaml
+++ b/charts/kpow-ce/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled (not .Values.gateway.enabled) -}}
 {{- $fullName := include "kpow-ce.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $pathType := .Values.ingress.pathType -}}

--- a/charts/kpow-ce/values.yaml
+++ b/charts/kpow-ce/values.yaml
@@ -69,6 +69,18 @@ ingress:
   tls: [ ]
   ingressClassName: ""
 
+gateway:
+  enabled: false
+  gatewayName: ""
+  gatewayNamespace: ""
+  annotations: {}
+  pathType: PathPrefix
+  hosts: []
+  # Example host configuration:
+  # - host: kpow-ce.example.com
+  #   paths:
+  #     - /
+
 # We recommend running Kpow Community w/ Guaranteed QOS
 # For a single cluster you can modify to 0.5CPU, 2GB heap, monitor performance afterwards and adjust as necessary.
 resources:

--- a/charts/kpow/templates/NOTES.txt
+++ b/charts/kpow/templates/NOTES.txt
@@ -5,6 +5,12 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
   {{- end }}
 {{- end }}
+{{- else if .Values.gateway.enabled }}
+{{- range $host := .Values.gateway.hosts }}
+  {{- range .paths }}
+  http://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kpow.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
@@ -18,4 +24,21 @@
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kpow.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:3000 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 3000:3000
+{{- end }}
+{{- if or .Values.ingressApi.enabled .Values.gatewayApi.enabled }}
+
+2. Get the API URL by running these commands:
+{{- if .Values.ingressApi.enabled }}
+{{- range $host := .Values.ingressApi.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingressApi.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if .Values.gatewayApi.enabled }}
+{{- range $host := .Values.gatewayApi.hosts }}
+  {{- range .paths }}
+  http://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/kpow/templates/gateway-api.yaml
+++ b/charts/kpow/templates/gateway-api.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.gatewayApi.enabled -}}
+{{- $fullName := include "kpow.fullname" . -}}
+{{- $apiPort := .Values.api.port -}}
+{{- $pathType := .Values.gatewayApi.pathType -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-api
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "kpow.labels" . | nindent 4 }}
+  {{- with .Values.gatewayApi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  - name: {{ .Values.gatewayApi.gatewayName }}
+    {{- if .Values.gatewayApi.gatewayNamespace }}
+    namespace: {{ .Values.gatewayApi.gatewayNamespace }}
+    {{- end }}
+  {{- if .Values.gatewayApi.hosts }}
+  hostnames:
+    {{- range .Values.gatewayApi.hosts }}
+    - {{ .host | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.gatewayApi.hosts }}
+    {{- range .paths }}
+    - matches:
+      - path:
+          type: {{ $pathType }}
+          value: {{ . | quote }}
+      backendRefs:
+      - name: {{ $fullName }}
+        port: {{ $apiPort }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/kpow/templates/gateway.yaml
+++ b/charts/kpow/templates/gateway.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "kpow.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $pathType := .Values.gateway.pathType -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "kpow.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  - name: {{ .Values.gateway.gatewayName }}
+    {{- if .Values.gateway.gatewayNamespace }}
+    namespace: {{ .Values.gateway.gatewayNamespace }}
+    {{- end }}
+  {{- if .Values.gateway.hosts }}
+  hostnames:
+    {{- range .Values.gateway.hosts }}
+    - {{ .host | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.gateway.hosts }}
+    {{- range .paths }}
+    - matches:
+      - path:
+          type: {{ $pathType }}
+          value: {{ . | quote }}
+      backendRefs:
+      - name: {{ $fullName }}
+        port: {{ $svcPort }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/kpow/templates/ingress-api.yaml
+++ b/charts/kpow/templates/ingress-api.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingressApi.enabled -}}
+{{- if and .Values.ingressApi.enabled (not .Values.gatewayApi.enabled) -}}
 {{- $fullName := include "kpow.fullname" . -}}
 {{- $apiPort := .Values.api.port -}}
 {{- $pathType := .Values.ingressApi.pathType -}}

--- a/charts/kpow/templates/ingress.yaml
+++ b/charts/kpow/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled (not .Values.gateway.enabled) -}}
 {{- $fullName := include "kpow.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $pathType := .Values.ingress.pathType -}}

--- a/charts/kpow/values.yaml
+++ b/charts/kpow/values.yaml
@@ -104,6 +104,32 @@ ingressApi:
   #   paths:
   #     - /
 
+gateway:
+  enabled: false
+  gatewayName: ""
+  gatewayNamespace: ""
+  annotations: {}
+  # The path type for HTTPRoute matches.
+  # Valid values are: PathPrefix, Exact.
+  pathType: PathPrefix
+  hosts: []
+  # Example host configuration:
+  # - host: kpow.example.com
+  #   paths:
+  #     - /
+
+gatewayApi:
+  enabled: false
+  gatewayName: ""
+  gatewayNamespace: ""
+  annotations: {}
+  pathType: PathPrefix
+  hosts: []
+  # Example host configuration:
+  # - host: kpow-api.example.com
+  #   paths:
+  #     - /
+
 # We recommend running Kpow w/ Guaranteed QOS
 # The default resource limit/requests are suitable for a multi-cluster installation (up to 12 Kafka Clusters + Connect + Schema).
 # For a smaller installation (up to 6 clusters) you can modify to 1CPU, 4GB heap, monitor performance afterwards and adjust as necessary.

--- a/charts/kpow/values.yaml
+++ b/charts/kpow/values.yaml
@@ -66,6 +66,39 @@ api:
   enabled: false
   port: 3001
 
+gateway:
+  enabled: false
+  gatewayName: ""
+  gatewayNamespace: ""
+  annotations: {}
+  # The path type for HTTPRoute matches.
+  # Valid values are: PathPrefix, Exact.
+  pathType: PathPrefix
+  hosts: []
+  # Example host configuration:
+  # - host: kpow.example.com
+  #   paths:
+  #     - /
+
+# HTTP Gateway
+#
+# Kpow supports either the traditional Ingress API for basic HTTP routing capabilities or
+# the next generation Gateway API for more advanced HTTP routing.
+#
+# Only one approach (ingress or gateway) can be enabled at a time
+
+gatewayApi:
+  enabled: false
+  gatewayName: ""
+  gatewayNamespace: ""
+  annotations: {}
+  pathType: PathPrefix
+  hosts: []
+  # Example host configuration:
+  # - host: kpow-api.example.com
+  #   paths:
+  #     - /
+
 ingress:
   enabled: false
   ingressClassName: ""
@@ -104,31 +137,7 @@ ingressApi:
   #   paths:
   #     - /
 
-gateway:
-  enabled: false
-  gatewayName: ""
-  gatewayNamespace: ""
-  annotations: {}
-  # The path type for HTTPRoute matches.
-  # Valid values are: PathPrefix, Exact.
-  pathType: PathPrefix
-  hosts: []
-  # Example host configuration:
-  # - host: kpow.example.com
-  #   paths:
-  #     - /
 
-gatewayApi:
-  enabled: false
-  gatewayName: ""
-  gatewayNamespace: ""
-  annotations: {}
-  pathType: PathPrefix
-  hosts: []
-  # Example host configuration:
-  # - host: kpow-api.example.com
-  #   paths:
-  #     - /
 
 # We recommend running Kpow w/ Guaranteed QOS
 # The default resource limit/requests are suitable for a multi-cluster installation (up to 12 Kafka Clusters + Connect + Schema).


### PR DESCRIPTION
Allows a customer to specify either `ingress` or `gateway` for each products UI or API.

Fixes #28